### PR TITLE
replace On/Off labels in notification preferences with gtk switch

### DIFF
--- a/data/ui/preferences-device-panel.ui
+++ b/data/ui/preferences-device-panel.ui
@@ -1159,7 +1159,7 @@
                             <property name="hexpand">True</property>
                             <property name="selection_mode">none</property>
                             <signal name="keynav-failed" handler="_onKeynavFailed" swapped="no"/>
-                            <signal name="row-activated" handler="_onNotificationRowActivated" swapped="no"/>
+                            <signal name="row-activated" handler="_onSectionRowActivated" swapped="no"/>
                             <accessibility>
                               <relation type="labelled-by" target="notification-apps-label"/>
                             </accessibility>


### PR DESCRIPTION
To get to know the project a little I decided to implement a change in UI where there was a little inconsistency of using On Off labels in *Notification Preferences* while Gtk Switch is used everywhere else. I hope it's ok.

I did it the same as it is in Plugins in the Advanced menu

![Screenshot from 2020-12-12 01-28-04](https://user-images.githubusercontent.com/1145361/101967905-eb568980-3c1c-11eb-874e-bba1bafcf8c0.png)

 _('On')  and  _('Off')  are probably not used anywhere else, is there anything needed to do with translations?