### PR TITLE
Messaging UI: Make contact number/name and message time selectable

### DIFF
--- a/data/ui/messaging-conversation-message.ui
+++ b/data/ui/messaging-conversation-message.ui
@@ -34,6 +34,7 @@
           <object class="GtkLabel" id="sender-label">
             <property name="halign">start</property>
             <property name="valign">start</property>
+            <property name="selectable">True</property>
             <property name="margin_start">6</property>
             <attributes>
               <attribute name="weight" value="bold"/>

--- a/src/service/ui/messaging.js
+++ b/src/service/ui/messaging.js
@@ -584,7 +584,7 @@ const Conversation = GObject.registerClass({
 
         if ((row.message.date - before.message.date) > TIME_SPAN_HOUR) {
             if (!header) {
-                header = new Gtk.Label({visible: true});
+                header = new Gtk.Label({visible: true, selectable: true});
                 header.get_style_context().add_class('dim-label');
                 row.set_header(header);
             }


### PR DESCRIPTION
Fixes https://github.com/GSConnect/gnome-shell-extension-gsconnect/issues/999