### PR TITLE
Add custom charge level notifications #872

### DIFF
--- a/data/org.gnome.Shell.Extensions.GSConnect.gschema.xml
+++ b/data/org.gnome.Shell.Extensions.GSConnect.gschema.xml
@@ -81,11 +81,12 @@
     <key name="low-battery-notification" type="b">
       <default>true</default>
     </key>
-    <key name="sixty-battery-notification" type="b">
-      <default>false</default>
+    <key name="custom-battery-notification" type="b">
+      <default>true</default>
+      <summary>Enables custom battery notification</summary>
     </key>
-    <key name="eighty-battery-notification" type="b">
-      <default>false</default>
+    <key name="custom-battery-notification-value" type="u">
+      <default>80</default>
     </key>
     <key name="full-battery-notification" type="b">
       <default>false</default>

--- a/data/org.gnome.Shell.Extensions.GSConnect.gschema.xml
+++ b/data/org.gnome.Shell.Extensions.GSConnect.gschema.xml
@@ -81,6 +81,12 @@
     <key name="low-battery-notification" type="b">
       <default>true</default>
     </key>
+    <key name="sixty-battery-notification" type="b">
+      <default>false</default>
+    </key>
+    <key name="eighty-battery-notification" type="b">
+      <default>false</default>
+    </key>
     <key name="full-battery-notification" type="b">
       <default>false</default>
     </key>

--- a/data/org.gnome.Shell.Extensions.GSConnect.gschema.xml
+++ b/data/org.gnome.Shell.Extensions.GSConnect.gschema.xml
@@ -82,10 +82,11 @@
       <default>true</default>
     </key>
     <key name="custom-battery-notification" type="b">
-      <default>true</default>
+      <default>false</default>
       <summary>Enables custom battery notification</summary>
     </key>
-    <key name="custom-battery-notification-value" type="u">
+    <key name="custom-battery-notification-value" type="d">
+      <range min="1" max="99"></range>
       <default>80</default>
     </key>
     <key name="full-battery-notification" type="b">

--- a/data/ui/preferences-device-panel.ui
+++ b/data/ui/preferences-device-panel.ui
@@ -732,7 +732,6 @@
                                         <property name="vexpand">True</property>
                                         <property name="label" translatable="yes">Set Custom Charge Level</property>
                                         <accessibility>
-                                          <relation type="label-for" target="battery-custom-notification-spin-row"/>
                                           <relation type="label-for" target="battery-custom-notification-spin"/>
                                         </accessibility>
                                       </object>
@@ -748,10 +747,6 @@
                                         <property name="valign">right</property>
                                         <property name="adjustment">custom-battery-adjustment</property>
                                         <signal name="value-changed" handler="_newCustomChargeLevel">
-                                        <accessibility>
-                                          <relation type="controlled-by" target="battery-custom-notification-spin-row"/>
-                                          <relation type="labelled-by" target="battery-custom-notification-spin-label"/>
-                                        </accessibility>
                                       </object>
                                       <packing>
                                         <property name="left_attach">1</property>

--- a/data/ui/preferences-device-panel.ui
+++ b/data/ui/preferences-device-panel.ui
@@ -603,7 +603,7 @@
                     <child>
                       <object class="GtkFrame" id="battery-device">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can_focus">True</property>
                         <property name="margin_bottom">32</property>
                         <property name="label_xalign">0</property>
                         <child>
@@ -677,12 +677,12 @@
                                 <property name="height_request">56</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
-                                <property name="action_name">settings.custom-battery-notification</property>
-                                <property name="selectable">False</property>
+                                <property name="activatable">True</property>
+                                <property name="action_name">settings.custom-battery-notification</property>                                
                                 <child>
                                   <object class="GtkGrid">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can_focus">True</property>
                                     <property name="margin_start">12</property>
                                     <property name="margin_end">12</property>
                                     <property name="hexpand">True</property>
@@ -691,7 +691,7 @@
                                     <child>
                                       <object class="GtkLabel" id="battery-custom-notification-label">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can_focus">True</property>
                                         <property name="halign">start</property>
                                         <property name="valign">center</property>
                                         <property name="hexpand">True</property>
@@ -728,7 +728,7 @@
                                       <object class="GtkSpinButton" id="battery-custom-notification-value">
                                         <property name="visible">True</property>
                                         <property name="value">80</property>
-                                        <property name="can_focus">True</property>
+                                        <property name="can_focus">False</property>
                                         <property name="max_length">2</property>
                                         <property name="activates_default">True</property>
                                         <property name="width_chars">2</property>

--- a/data/ui/preferences-device-panel.ui
+++ b/data/ui/preferences-device-panel.ui
@@ -564,6 +564,12 @@
                 <property name="can_focus">False</property>
                 <property name="shadow_type">none</property>
                 <child>
+                  <object class="GtkAdjustment" id="custom-battery-adjustment">
+                    <property name="upper">99</property>
+                    <property name="lower">01</property>
+                    <property name="step_increment">1</property>
+                    <property name="page_increment">5</property>
+                  </object>
                   <object class="GtkBox">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
@@ -666,11 +672,11 @@
                               </object>
                             </child>
                             <child>
-                              <object class="GtkListBoxRow" id="battery-sixty-notification-row">
+                              <object class="GtkListBoxRow" id="battery-custom-notification-row">
                                 <property name="height_request">56</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
-                                <property name="action_name">settings.sixty-battery-notification</property>
+                                <property name="action_name">settings.custom-battery-notification</property>
                                 <property name="selectable">False</property>
                                 <child>
                                   <object class="GtkGrid">
@@ -682,17 +688,17 @@
                                     <property name="vexpand">True</property>
                                     <property name="column_spacing">12</property>
                                     <child>
-                                      <object class="GtkLabel" id="battery-sixty-notification-label">
+                                      <object class="GtkLabel" id="battery-custom-notification-label">
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
                                         <property name="halign">start</property>
                                         <property name="valign">center</property>
                                         <property name="hexpand">True</property>
                                         <property name="vexpand">True</property>
-                                        <property name="label" translatable="yes">60% Charged Notification</property>
+                                        <property name="label" translatable="yes">Custom Charge Level Notification</property>
                                         <accessibility>
-                                          <relation type="label-for" target="battery-sixty-notification-row"/>
-                                          <relation type="label-for" target="battery-sixty-notification"/>
+                                          <relation type="label-for" target="battery-custom-notification-row"/>
+                                          <relation type="label-for" target="battery-custom-notification"/>
                                         </accessibility>
                                       </object>
                                       <packing>
@@ -701,14 +707,14 @@
                                       </packing>
                                     </child>
                                     <child>
-                                      <object class="GtkSwitch" id="battery-sixty-notification">
+                                      <object class="GtkSwitch" id="battery-custom-notification">
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="valign">center</property>
-                                        <property name="action_name">settings.sixty-battery-notification</property>
+                                        <property name="action_name">settings.custom-battery-notification</property>
                                         <accessibility>
-                                          <relation type="controlled-by" target="battery-sixty-notification-row"/>
-                                          <relation type="labelled-by" target="battery-sixty-notification-label"/>
+                                          <relation type="controlled-by" target="battery-custom-notification-row"/>
+                                          <relation type="labelled-by" target="battery-custom-notification-label"/>
                                         </accessibility>
                                       </object>
                                       <packing>
@@ -716,70 +722,47 @@
                                         <property name="top_attach">0</property>
                                       </packing>
                                     </child>
-                                  </object>
-                                </child>
-                                <accessibility>
-                                  <relation type="controller-for" target="battery-sixty-notification"/>
-                                  <relation type="labelled-by" target="battery-sixty-notification-label"/>
-                                </accessibility>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkListBoxRow" id="battery-eighty-notification-row">
-                                <property name="height_request">56</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="action_name">settings.eighty-battery-notification</property>
-                                <property name="selectable">False</property>
-                                <child>
-                                  <object class="GtkGrid">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="margin_start">12</property>
-                                    <property name="margin_end">12</property>
-                                    <property name="hexpand">True</property>
-                                    <property name="vexpand">True</property>
-                                    <property name="column_spacing">12</property>
                                     <child>
-                                      <object class="GtkLabel" id="battery-eighty-notification-label">
+                                      <object class="GtkLabel" id="battery-custom-notification-spin-label">
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
                                         <property name="halign">start</property>
                                         <property name="valign">center</property>
                                         <property name="hexpand">True</property>
                                         <property name="vexpand">True</property>
-                                        <property name="label" translatable="yes">80% Charged Notification</property>
+                                        <property name="label" translatable="yes">Set Custom Charge Level</property>
                                         <accessibility>
-                                          <relation type="label-for" target="battery-eighty-notification-row"/>
-                                          <relation type="label-for" target="battery-eighty-notification"/>
+                                          <relation type="label-for" target="battery-custom-notification-spin-row"/>
+                                          <relation type="label-for" target="battery-custom-notification-spin"/>
                                         </accessibility>
                                       </object>
                                       <packing>
                                         <property name="left_attach">0</property>
-                                        <property name="top_attach">0</property>
+                                        <property name="top_attach">1</property>
                                       </packing>
                                     </child>
                                     <child>
-                                      <object class="GtkSwitch" id="battery-eighty-notification">
+                                      <object class="GtkSpinButton" id="battery-custom-notification-spin">
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
-                                        <property name="valign">center</property>
-                                        <property name="action_name">settings.eighty-battery-notification</property>
+                                        <property name="valign">right</property>
+                                        <property name="adjustment">custom-battery-adjustment</property>
+                                        <signal name="value-changed" handler="_newCustomChargeLevel">
                                         <accessibility>
-                                          <relation type="controlled-by" target="battery-eighty-notification-row"/>
-                                          <relation type="labelled-by" target="battery-eighty-notification-label"/>
+                                          <relation type="controlled-by" target="battery-custom-notification-spin-row"/>
+                                          <relation type="labelled-by" target="battery-custom-notification-spin-label"/>
                                         </accessibility>
                                       </object>
                                       <packing>
                                         <property name="left_attach">1</property>
-                                        <property name="top_attach">0</property>
+                                        <property name="top_attach">1</property>
                                       </packing>
                                     </child>
                                   </object>
                                 </child>
                                 <accessibility>
-                                  <relation type="controller-for" target="battery-eighty-notification"/>
-                                  <relation type="labelled-by" target="battery-eighty-notification-label"/>
+                                  <relation type="controller-for" target="battery-custom-notification"/>
+                                  <relation type="labelled-by" target="battery-custom-notification-label"/>
                                 </accessibility>
                               </object>
                             </child>

--- a/data/ui/preferences-device-panel.ui
+++ b/data/ui/preferences-device-panel.ui
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface domain="org.gnome.Shell.Extensions.GSConnect">
   <requires lib="gtk+" version="3.24"/>
+  <object class="GtkAdjustment" id="battery-custom-adjustment">
+    <property name="upper">99</property>
+    <property name="lower">01</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">5</property>
+  </object>                                         
   <template class="GSConnectPreferencesDevicePanel" parent="GtkGrid">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -693,6 +699,7 @@
                                         <accessibility>
                                           <relation type="label-for" target="battery-custom-notification-row"/>
                                           <relation type="label-for" target="battery-custom-notification"/>
+                                          <relation type="label-for" target="battery-custom-notification-spin"/>
                                         </accessibility>
                                       </object>
                                       <packing>
@@ -712,48 +719,30 @@
                                         </accessibility>
                                       </object>
                                       <packing>
-                                        <property name="left_attach">1</property>
+                                        <property name="left_attach">2</property>
                                         <property name="top_attach">0</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkLabel" id="battery-custom-notification-spin-label">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="halign">start</property>
-                                        <property name="valign">center</property>
-                                        <property name="hexpand">True</property>
-                                        <property name="vexpand">True</property>
-                                        <property name="label" translatable="yes">Set Custom Charge Level</property>
-                                        <accessibility>
-                                          <relation type="label-for" target="battery-custom-notification-spin"/>
-                                        </accessibility>
-                                      </object>
-                                      <packing>
-                                        <property name="left_attach">0</property>
-                                        <property name="top_attach">1</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkSpinButton" id="battery-custom-notification-spin">
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
-                                        <property name="valign">right</property>
-                                        <property name="adjustment">
-                                          <object class="GtkAdjustment">
-                                            <property name="upper">99</property>
-                                            <property name="lower">01</property>
-                                            <property name="step_increment">1</property>
-                                            <property name="page_increment">5</property>
-                                          </object>
-                                        </property>
-                                        <signal name="value-changed" handler="_newCustomChargeLevel">
+                                        <property name="max_length">2</property>
+                                        <property name="activates_default">True</property>
+                                        <property name="width_chars">2</property>
+                                        <property name="input_purpose">digits</property>
+                                        <property name="adjustment">battery-custom-adjustment</property>
+                                        <signal name="value-changed" handler="_newCustomChargeLevel" swapped="no"></signal>
+                                        <accessibility>
+                                          <relation type="controlled-by" target="battery-custom-notification-row"/>
+                                          <relation type="labelled-by" target="battery-custom-notification-label"/>
+                                        </accessibility>
                                       </object>
                                       <packing>
                                         <property name="left_attach">1</property>
-                                        <property name="top_attach">1</property>
+                                        <property name="top_attach">0</property>
                                       </packing>
-                                    </child>
+                                    </child>                                    
                                   </object>
                                 </child>
                                 <accessibility>

--- a/data/ui/preferences-device-panel.ui
+++ b/data/ui/preferences-device-panel.ui
@@ -563,13 +563,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="shadow_type">none</property>
-                <child>
-                  <object class="GtkAdjustment" id="custom-battery-adjustment">
-                    <property name="upper">99</property>
-                    <property name="lower">01</property>
-                    <property name="step_increment">1</property>
-                    <property name="page_increment">5</property>
-                  </object>
+                <child>                  
                   <object class="GtkBox">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
@@ -745,7 +739,14 @@
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="valign">right</property>
-                                        <property name="adjustment">custom-battery-adjustment</property>
+                                        <property name="adjustment">
+                                          <object class="GtkAdjustment">
+                                            <property name="upper">99</property>
+                                            <property name="lower">01</property>
+                                            <property name="step_increment">1</property>
+                                            <property name="page_increment">5</property>
+                                          </object>
+                                        </property>
                                         <signal name="value-changed" handler="_newCustomChargeLevel">
                                       </object>
                                       <packing>

--- a/data/ui/preferences-device-panel.ui
+++ b/data/ui/preferences-device-panel.ui
@@ -2,6 +2,7 @@
 <interface domain="org.gnome.Shell.Extensions.GSConnect">
   <requires lib="gtk+" version="3.24"/>
   <object class="GtkAdjustment" id="battery-custom-adjustment">
+    <property name="value">80</property>
     <property name="upper">99</property>
     <property name="lower">01</property>
     <property name="step_increment">1</property>
@@ -699,7 +700,7 @@
                                         <accessibility>
                                           <relation type="label-for" target="battery-custom-notification-row"/>
                                           <relation type="label-for" target="battery-custom-notification"/>
-                                          <relation type="label-for" target="battery-custom-notification-spin"/>
+                                          <relation type="label-for" target="battery-custom-notification-value"/>
                                         </accessibility>
                                       </object>
                                       <packing>
@@ -724,15 +725,15 @@
                                       </packing>
                                     </child>
                                     <child>
-                                      <object class="GtkSpinButton" id="battery-custom-notification-spin">
+                                      <object class="GtkSpinButton" id="battery-custom-notification-value">
                                         <property name="visible">True</property>
+                                        <property name="value">80</property>
                                         <property name="can_focus">True</property>
                                         <property name="max_length">2</property>
                                         <property name="activates_default">True</property>
                                         <property name="width_chars">2</property>
-                                        <property name="input_purpose">digits</property>
                                         <property name="adjustment">battery-custom-adjustment</property>
-                                        <signal name="value-changed" handler="_newCustomChargeLevel" swapped="no"></signal>
+                                        <signal name="output" handler="_setCustomChargeLevel" swapped="no"></signal>
                                         <accessibility>
                                           <relation type="controlled-by" target="battery-custom-notification-row"/>
                                           <relation type="labelled-by" target="battery-custom-notification-label"/>

--- a/data/ui/preferences-device-panel.ui
+++ b/data/ui/preferences-device-panel.ui
@@ -666,6 +666,124 @@
                               </object>
                             </child>
                             <child>
+                              <object class="GtkListBoxRow" id="battery-sixty-notification-row">
+                                <property name="height_request">56</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="action_name">settings.sixty-battery-notification</property>
+                                <property name="selectable">False</property>
+                                <child>
+                                  <object class="GtkGrid">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_start">12</property>
+                                    <property name="margin_end">12</property>
+                                    <property name="hexpand">True</property>
+                                    <property name="vexpand">True</property>
+                                    <property name="column_spacing">12</property>
+                                    <child>
+                                      <object class="GtkLabel" id="battery-sixty-notification-label">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="halign">start</property>
+                                        <property name="valign">center</property>
+                                        <property name="hexpand">True</property>
+                                        <property name="vexpand">True</property>
+                                        <property name="label" translatable="yes">60% Charged Notification</property>
+                                        <accessibility>
+                                          <relation type="label-for" target="battery-sixty-notification-row"/>
+                                          <relation type="label-for" target="battery-sixty-notification"/>
+                                        </accessibility>
+                                      </object>
+                                      <packing>
+                                        <property name="left_attach">0</property>
+                                        <property name="top_attach">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSwitch" id="battery-sixty-notification">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="valign">center</property>
+                                        <property name="action_name">settings.sixty-battery-notification</property>
+                                        <accessibility>
+                                          <relation type="controlled-by" target="battery-sixty-notification-row"/>
+                                          <relation type="labelled-by" target="battery-sixty-notification-label"/>
+                                        </accessibility>
+                                      </object>
+                                      <packing>
+                                        <property name="left_attach">1</property>
+                                        <property name="top_attach">0</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                </child>
+                                <accessibility>
+                                  <relation type="controller-for" target="battery-sixty-notification"/>
+                                  <relation type="labelled-by" target="battery-sixty-notification-label"/>
+                                </accessibility>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkListBoxRow" id="battery-eighty-notification-row">
+                                <property name="height_request">56</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="action_name">settings.eighty-battery-notification</property>
+                                <property name="selectable">False</property>
+                                <child>
+                                  <object class="GtkGrid">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_start">12</property>
+                                    <property name="margin_end">12</property>
+                                    <property name="hexpand">True</property>
+                                    <property name="vexpand">True</property>
+                                    <property name="column_spacing">12</property>
+                                    <child>
+                                      <object class="GtkLabel" id="battery-eighty-notification-label">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="halign">start</property>
+                                        <property name="valign">center</property>
+                                        <property name="hexpand">True</property>
+                                        <property name="vexpand">True</property>
+                                        <property name="label" translatable="yes">80% Charged Notification</property>
+                                        <accessibility>
+                                          <relation type="label-for" target="battery-eighty-notification-row"/>
+                                          <relation type="label-for" target="battery-eighty-notification"/>
+                                        </accessibility>
+                                      </object>
+                                      <packing>
+                                        <property name="left_attach">0</property>
+                                        <property name="top_attach">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSwitch" id="battery-eighty-notification">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="valign">center</property>
+                                        <property name="action_name">settings.eighty-battery-notification</property>
+                                        <accessibility>
+                                          <relation type="controlled-by" target="battery-eighty-notification-row"/>
+                                          <relation type="labelled-by" target="battery-eighty-notification-label"/>
+                                        </accessibility>
+                                      </object>
+                                      <packing>
+                                        <property name="left_attach">1</property>
+                                        <property name="top_attach">0</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                </child>
+                                <accessibility>
+                                  <relation type="controller-for" target="battery-eighty-notification"/>
+                                  <relation type="labelled-by" target="battery-eighty-notification-label"/>
+                                </accessibility>
+                              </object>
+                            </child>
+                            <child>
                               <object class="GtkListBoxRow" id="battery-full-notification-row">
                                 <property name="height_request">56</property>
                                 <property name="visible">True</property>

--- a/installed-tests/suites/plugins/testBatteryPlugin.js
+++ b/installed-tests/suites/plugins/testBatteryPlugin.js
@@ -154,24 +154,7 @@ describe('The battery plugin', function () {
             Packets.goodBattery.body);
         expect(remotePlugin.device.hideNotification).toHaveBeenCalled();
     });
-
-    it('notifies when the battery is at 60%', async function () {
-        
-        localPlugin.device.sendPacket(Packets.sixtyBattery);
-
-        await remotePlugin.awaitPacket('kdeconnect.battery',
-            Packets.sixtyBattery.body);
-        expect(remotePlugin.device.showNotification).toHaveBeenCalled();
-    });
-
-    it('withdraws 60% battery notifications', async function () {
-        localPlugin.device.sendPacket(Packets.goodBattery);
-
-        await remotePlugin.awaitPacket('kdeconnect.battery',
-            Packets.goodBattery.body);
-        expect(remotePlugin.device.hideNotification).toHaveBeenCalled();
-    });
-
+    
     it('notifies when the battery is at 80%', async function () {
         localPlugin.device.sendPacket(Packets.eightyBattery);
 

--- a/installed-tests/suites/plugins/testBatteryPlugin.js
+++ b/installed-tests/suites/plugins/testBatteryPlugin.js
@@ -20,15 +20,7 @@ const Packets = {
             thresholdEvent: 1,
         },
     },
-    sixtyBattery: {
-        type: 'kdeconnect.battery',
-        body: {
-            currentCharge: 60,
-            isCharging: true,
-            thresholdEvent: 0,
-        },
-    },
-    eightyBattery: {
+    customBattery: {
         type: 'kdeconnect.battery',
         body: {
             currentCharge: 80,
@@ -155,15 +147,16 @@ describe('The battery plugin', function () {
         expect(remotePlugin.device.hideNotification).toHaveBeenCalled();
     });
     
-    it('notifies when the battery is at 80%', async function () {
-        localPlugin.device.sendPacket(Packets.eightyBattery);
+    it('notifies when the battery is at custom level', async function () {
+        remotePlugin.settings.set_boolean('custom-battery-notification', true);
+        localPlugin.device.sendPacket(Packets.customBattery);
 
         await remotePlugin.awaitPacket('kdeconnect.battery',
-            Packets.eightyBattery.body);
+            Packets.customBattery.body);
         expect(remotePlugin.device.showNotification).toHaveBeenCalled();
     });
 
-    it('withdraws 80% battery notifications', async function () {
+    it('withdraws custom battery notifications', async function () {
         localPlugin.device.sendPacket(Packets.goodBattery);
 
         await remotePlugin.awaitPacket('kdeconnect.battery',

--- a/installed-tests/suites/plugins/testBatteryPlugin.js
+++ b/installed-tests/suites/plugins/testBatteryPlugin.js
@@ -159,7 +159,7 @@ describe('The battery plugin', function () {
         localPlugin.device.sendPacket(Packets.sixtyBattery);
 
         await remotePlugin.awaitPacket('kdeconnect.battery',
-            Packets.lowBattery.body);
+            Packets.sixtyBattery.body);
         expect(remotePlugin.device.showNotification).toHaveBeenCalled();
     });
 
@@ -175,7 +175,7 @@ describe('The battery plugin', function () {
         localPlugin.device.sendPacket(Packets.eightyBattery);
 
         await remotePlugin.awaitPacket('kdeconnect.battery',
-            Packets.lowBattery.body);
+            Packets.eightyBattery.body);
         expect(remotePlugin.device.showNotification).toHaveBeenCalled();
     });
 

--- a/installed-tests/suites/plugins/testBatteryPlugin.js
+++ b/installed-tests/suites/plugins/testBatteryPlugin.js
@@ -146,7 +146,7 @@ describe('The battery plugin', function () {
             Packets.goodBattery.body);
         expect(remotePlugin.device.hideNotification).toHaveBeenCalled();
     });
-    
+
     it('notifies when the battery is at custom level', async function () {
         remotePlugin.settings.set_boolean('custom-battery-notification', true);
         localPlugin.device.sendPacket(Packets.customBattery);

--- a/installed-tests/suites/plugins/testBatteryPlugin.js
+++ b/installed-tests/suites/plugins/testBatteryPlugin.js
@@ -20,6 +20,22 @@ const Packets = {
             thresholdEvent: 1,
         },
     },
+    sixtyBattery: {
+        type: 'kdeconnect.battery',
+        body: {
+            currentCharge: 60,
+            isCharging: true,
+            thresholdEvent: 0,
+        },
+    },
+    eightyBattery: {
+        type: 'kdeconnect.battery',
+        body: {
+            currentCharge: 80,
+            isCharging: true,
+            thresholdEvent: 0,
+        },
+    },
     fullBattery: {
         type: 'kdeconnect.battery',
         body: {
@@ -132,6 +148,38 @@ describe('The battery plugin', function () {
     });
 
     it('withdraws low battery notifications', async function () {
+        localPlugin.device.sendPacket(Packets.goodBattery);
+
+        await remotePlugin.awaitPacket('kdeconnect.battery',
+            Packets.goodBattery.body);
+        expect(remotePlugin.device.hideNotification).toHaveBeenCalled();
+    });
+
+    it('notifies when the battery is at 60%', async function () {
+        localPlugin.device.sendPacket(Packets.sixtyBattery);
+
+        await remotePlugin.awaitPacket('kdeconnect.battery',
+            Packets.lowBattery.body);
+        expect(remotePlugin.device.showNotification).toHaveBeenCalled();
+    });
+
+    it('withdraws 60% battery notifications', async function () {
+        localPlugin.device.sendPacket(Packets.goodBattery);
+
+        await remotePlugin.awaitPacket('kdeconnect.battery',
+            Packets.goodBattery.body);
+        expect(remotePlugin.device.hideNotification).toHaveBeenCalled();
+    });
+
+    it('notifies when the battery is at 80%', async function () {
+        localPlugin.device.sendPacket(Packets.eightyBattery);
+
+        await remotePlugin.awaitPacket('kdeconnect.battery',
+            Packets.lowBattery.body);
+        expect(remotePlugin.device.showNotification).toHaveBeenCalled();
+    });
+
+    it('withdraws 80% battery notifications', async function () {
         localPlugin.device.sendPacket(Packets.goodBattery);
 
         await remotePlugin.awaitPacket('kdeconnect.battery',

--- a/installed-tests/suites/plugins/testBatteryPlugin.js
+++ b/installed-tests/suites/plugins/testBatteryPlugin.js
@@ -156,6 +156,7 @@ describe('The battery plugin', function () {
     });
 
     it('notifies when the battery is at 60%', async function () {
+        
         localPlugin.device.sendPacket(Packets.sixtyBattery);
 
         await remotePlugin.awaitPacket('kdeconnect.battery',

--- a/src/preferences/device.js
+++ b/src/preferences/device.js
@@ -615,9 +615,8 @@ var Panel = GObject.registerClass({
 
     _newCustomChargeLevel() {
         const settings = this.pluginSettings('battery');
-        this.set_value(settings.get_uint('custom-battery-notification-value'));
-        this.connect('value-changed', function (button) {
-            settings.set_uint('custom-battery-notification-value', button.get_value_as_int());
+        this.connect('notify::value-changed', function (button) {
+            settings.set_uint('custom-battery-notification-value', button);
         });
     }
 

--- a/src/preferences/device.js
+++ b/src/preferences/device.js
@@ -434,8 +434,8 @@ var Panel = GObject.registerClass({
         let settings = this.pluginSettings('battery');
         this.actions.add_action(settings.create_action('send-statistics'));
         this.actions.add_action(settings.create_action('low-battery-notification'));
-        this.actions.add_action(settings.create_action('sixty-battery-notification'));
-        this.actions.add_action(settings.create_action('eighty-battery-notification'));
+        this.actions.add_action(settings.create_action('custom-battery-notification'));
+        this.actions.add_action(settings.create_action('custom-battery-notification-value'));
         this.actions.add_action(settings.create_action('full-battery-notification'));
 
         settings = this.pluginSettings('clipboard');
@@ -611,6 +611,13 @@ var Panel = GObject.registerClass({
             this.battery_system_label.visible = false;
             this.battery_system.visible = false;
         }
+    }
+
+    _newCustomChargeLevel() {
+        input.set_value(settings.get_uint('custom-battery-notification-value'));
+        input.connect('value-changed', function(button) {
+            settings.set_uint('custom-battery-notification-value', button.get_value_as_int());
+        })
     }
 
     /**

--- a/src/preferences/device.js
+++ b/src/preferences/device.js
@@ -434,6 +434,8 @@ var Panel = GObject.registerClass({
         let settings = this.pluginSettings('battery');
         this.actions.add_action(settings.create_action('send-statistics'));
         this.actions.add_action(settings.create_action('low-battery-notification'));
+        this.actions.add_action(settings.create_action('sixty-battery-notification'));
+        this.actions.add_action(settings.create_action('eighty-battery-notification'));
         this.actions.add_action(settings.create_action('full-battery-notification'));
 
         settings = this.pluginSettings('clipboard');

--- a/src/preferences/device.js
+++ b/src/preferences/device.js
@@ -614,10 +614,11 @@ var Panel = GObject.registerClass({
     }
 
     _newCustomChargeLevel() {
-        input.set_value(settings.get_uint('custom-battery-notification-value'));
-        input.connect('value-changed', function(button) {
+        const settings = this.pluginSettings('battery');
+        this.set_value(settings.get_uint('custom-battery-notification-value'));
+        this.connect('value-changed', function (button) {
             settings.set_uint('custom-battery-notification-value', button.get_value_as_int());
-        })
+        });
     }
 
     /**

--- a/src/preferences/device.js
+++ b/src/preferences/device.js
@@ -613,11 +613,13 @@ var Panel = GObject.registerClass({
         }
     }
 
-    _newCustomChargeLevel() {
+    _setCustomChargeLevel(spin) {
         const settings = this.pluginSettings('battery');
-        this.connect('notify::value-changed', function (button) {
-            settings.set_uint('custom-battery-notification-value', button);
-        });
+        const oldLevel = settings.get_value('custom-battery-notification-value').unpack();
+        const newLevel = GLib.Variant.new('d', spin.get_value());
+
+        if (newLevel !== oldLevel)
+            settings.set_value('custom-battery-notification-value', newLevel);
     }
 
     /**

--- a/src/service/plugins/battery.js
+++ b/src/service/plugins/battery.js
@@ -277,9 +277,9 @@ var Plugin = GObject.registerClass({
 
         this.device.showNotification({
             id: 'battery|sixty',
-            // TRANSLATORS: eg. Google Pixel: Battery is full
+            // TRANSLATORS: eg. Google Pixel: Battery is 60% charged
             title: _('%s: Battery is 60% Charged').format(this.device.name),
-            // TRANSLATORS: when the battery is fully charged
+            // TRANSLATORS: when the battery is 60% charged
             body: _('60% Charged'),
             icon: Gio.ThemedIcon.new('battery-full-charged-symbolic'),
             buttons: buttons,
@@ -306,9 +306,9 @@ var Plugin = GObject.registerClass({
 
         this.device.showNotification({
             id: 'battery|eighty',
-            // TRANSLATORS: eg. Google Pixel: Battery is full
+            // TRANSLATORS: eg. Google Pixel: Battery is 80% Charged
             title: _('%s: Battery is 80% Charged').format(this.device.name),
-            // TRANSLATORS: when the battery is fully charged
+            // TRANSLATORS: when the battery is 80% charged
             body: _('80% Charged'),
             icon: Gio.ThemedIcon.new('battery-full-charged-symbolic'),
             buttons: buttons,

--- a/src/service/plugins/battery.js
+++ b/src/service/plugins/battery.js
@@ -332,8 +332,8 @@ var Plugin = GObject.registerClass({
             if (this._level > this._thresholdLevel)
                 this.device.hideNotification('battery|low');
 
-            // The level just changed to/from 60% while charging
-            if (this._level === this.settings.get_uint('custom-battery-notification-value') && this._charging)
+            // The level just changed to/from custom level while charging
+            if ((this._level === this.settings.get_value('custom-battery-notification-value').unpack()) && this._charging)
                 this._customBatteryNotification();
             else
                 this.device.hideNotification('battery|custom');

--- a/src/service/plugins/battery.js
+++ b/src/service/plugins/battery.js
@@ -256,6 +256,7 @@ var Plugin = GObject.registerClass({
             buttons: buttons,
         });
     }
+
     /**
      * Notify the user the remote battery is at 60% charge.
      */
@@ -284,6 +285,7 @@ var Plugin = GObject.registerClass({
             buttons: buttons,
         });
     }
+
     /**
      * Notify the user the remote battery is at 80% charge.
      */
@@ -312,6 +314,7 @@ var Plugin = GObject.registerClass({
             buttons: buttons,
         });
     }
+
     /**
      * Notify the user the remote battery is low.
      */
@@ -363,7 +366,7 @@ var Plugin = GObject.registerClass({
                 this._sixtyBatteryNotification();
             else
                 this.device.hideNotification('battery|sixty');
-            
+
             // The level just changed to/from 80%
             if (this._level === 80)
                 this._eightyBatteryNotification();

--- a/src/service/plugins/battery.js
+++ b/src/service/plugins/battery.js
@@ -258,10 +258,10 @@ var Plugin = GObject.registerClass({
     }
 
     /**
-     * Notify the user the remote battery is at 60% charge.
+     * Notify the user the remote battery is at custom charge level.
      */
-    _sixtyBatteryNotification() {
-        if (!this.settings.get_boolean('sixty-battery-notification'))
+    _customBatteryNotification() {
+        if (!this.settings.get_boolean('custom-battery-notification'))
             return;
 
         // Offer the option to ring the device, if available
@@ -276,40 +276,11 @@ var Plugin = GObject.registerClass({
         }
 
         this.device.showNotification({
-            id: 'battery|sixty',
-            // TRANSLATORS: eg. Google Pixel: Battery is 60% charged
-            title: _('%s: Battery is 60%% Charged').format(this.device.name),
-            // TRANSLATORS: when the battery is 60% charged
-            body: _('60% Charged'),
-            icon: Gio.ThemedIcon.new('battery-full-charged-symbolic'),
-            buttons: buttons,
-        });
-    }
-
-    /**
-     * Notify the user the remote battery is at 80% charge.
-     */
-    _eightyBatteryNotification() {
-        if (!this.settings.get_boolean('eighty-battery-notification'))
-            return;
-
-        // Offer the option to ring the device, if available
-        let buttons = [];
-
-        if (this.device.get_action_enabled('ring')) {
-            buttons = [{
-                label: _('Ring'),
-                action: 'ring',
-                parameter: null,
-            }];
-        }
-
-        this.device.showNotification({
-            id: 'battery|eighty',
-            // TRANSLATORS: eg. Google Pixel: Battery is 80% Charged
-            title: _('%s: Battery is 80%% Charged').format(this.device.name),
-            // TRANSLATORS: when the battery is 80% charged
-            body: _('80% Charged'),
+            id: 'battery|custom',
+            // TRANSLATORS: eg. Google Pixel: Battery has reached custom charge level
+            title: _('%s: Battery has reached custom charge level').format(this.device.name),
+            // TRANSLATORS: when the battery has reached custom charge level
+            body: _('%d%% Charged').format(this.level),
             icon: Gio.ThemedIcon.new('battery-full-charged-symbolic'),
             buttons: buttons,
         });
@@ -362,16 +333,10 @@ var Plugin = GObject.registerClass({
                 this.device.hideNotification('battery|low');
 
             // The level just changed to/from 60% while charging
-            if (this._level > 59 && this._charging)
-                this._sixtyBatteryNotification();
+            if (this._level === this.settings.get_uint('custom-battery-notification-value') && this._charging)
+                this._customBatteryNotification();
             else
-                this.device.hideNotification('battery|sixty');
-
-            // The level just changed to/from 80% while charging
-            if (this._level > 79 && this._charging)
-                this._eightyBatteryNotification();
-            else
-                this.device.hideNotification('battery|eighty');
+                this.device.hideNotification('battery|custom');
 
             // The level just changed to/from full
             if (this._level === 100)

--- a/src/service/plugins/battery.js
+++ b/src/service/plugins/battery.js
@@ -278,7 +278,7 @@ var Plugin = GObject.registerClass({
         this.device.showNotification({
             id: 'battery|sixty',
             // TRANSLATORS: eg. Google Pixel: Battery is 60% charged
-            title: _('%s: Battery is 60% Charged').format(this.device.name),
+            title: _('%s: Battery is 60%% Charged').format(this.device.name),
             // TRANSLATORS: when the battery is 60% charged
             body: _('60% Charged'),
             icon: Gio.ThemedIcon.new('battery-full-charged-symbolic'),
@@ -307,7 +307,7 @@ var Plugin = GObject.registerClass({
         this.device.showNotification({
             id: 'battery|eighty',
             // TRANSLATORS: eg. Google Pixel: Battery is 80% Charged
-            title: _('%s: Battery is 80% Charged').format(this.device.name),
+            title: _('%s: Battery is 80%% Charged').format(this.device.name),
             // TRANSLATORS: when the battery is 80% charged
             body: _('80% Charged'),
             icon: Gio.ThemedIcon.new('battery-full-charged-symbolic'),
@@ -361,13 +361,13 @@ var Plugin = GObject.registerClass({
             if (this._level > this._thresholdLevel)
                 this.device.hideNotification('battery|low');
 
-            // The level just changed to/from 60%
+            // The level just changed to/from 60% while charging
             if (this._level === 60)
                 this._sixtyBatteryNotification();
             else
                 this.device.hideNotification('battery|sixty');
 
-            // The level just changed to/from 80%
+            // The level just changed to/from 80% while charging
             if (this._level === 80)
                 this._eightyBatteryNotification();
             else

--- a/src/service/plugins/battery.js
+++ b/src/service/plugins/battery.js
@@ -362,13 +362,13 @@ var Plugin = GObject.registerClass({
                 this.device.hideNotification('battery|low');
 
             // The level just changed to/from 60% while charging
-            if (this._level === 60)
+            if (this._level === 60 && this._charging)
                 this._sixtyBatteryNotification();
             else
                 this.device.hideNotification('battery|sixty');
 
             // The level just changed to/from 80% while charging
-            if (this._level === 80)
+            if (this._level === 80 && this._charging)
                 this._eightyBatteryNotification();
             else
                 this.device.hideNotification('battery|eighty');

--- a/src/service/plugins/battery.js
+++ b/src/service/plugins/battery.js
@@ -362,13 +362,13 @@ var Plugin = GObject.registerClass({
                 this.device.hideNotification('battery|low');
 
             // The level just changed to/from 60% while charging
-            if (this._level === 60 && this._charging)
+            if (this._level > 59 && this._charging)
                 this._sixtyBatteryNotification();
             else
                 this.device.hideNotification('battery|sixty');
 
             // The level just changed to/from 80% while charging
-            if (this._level === 80 && this._charging)
+            if (this._level > 79 && this._charging)
                 this._eightyBatteryNotification();
             else
                 this.device.hideNotification('battery|eighty');

--- a/src/service/plugins/battery.js
+++ b/src/service/plugins/battery.js
@@ -256,7 +256,62 @@ var Plugin = GObject.registerClass({
             buttons: buttons,
         });
     }
+    /**
+     * Notify the user the remote battery is at 60% charge.
+     */
+    _sixtyBatteryNotification() {
+        if (!this.settings.get_boolean('sixty-battery-notification'))
+            return;
 
+        // Offer the option to ring the device, if available
+        let buttons = [];
+
+        if (this.device.get_action_enabled('ring')) {
+            buttons = [{
+                label: _('Ring'),
+                action: 'ring',
+                parameter: null,
+            }];
+        }
+
+        this.device.showNotification({
+            id: 'battery|sixty',
+            // TRANSLATORS: eg. Google Pixel: Battery is full
+            title: _('%s: Battery is 60% Charged').format(this.device.name),
+            // TRANSLATORS: when the battery is fully charged
+            body: _('60% Charged'),
+            icon: Gio.ThemedIcon.new('battery-full-charged-symbolic'),
+            buttons: buttons,
+        });
+    }
+    /**
+     * Notify the user the remote battery is at 80% charge.
+     */
+    _eightyBatteryNotification() {
+        if (!this.settings.get_boolean('eighty-battery-notification'))
+            return;
+
+        // Offer the option to ring the device, if available
+        let buttons = [];
+
+        if (this.device.get_action_enabled('ring')) {
+            buttons = [{
+                label: _('Ring'),
+                action: 'ring',
+                parameter: null,
+            }];
+        }
+
+        this.device.showNotification({
+            id: 'battery|eighty',
+            // TRANSLATORS: eg. Google Pixel: Battery is full
+            title: _('%s: Battery is 80% Charged').format(this.device.name),
+            // TRANSLATORS: when the battery is fully charged
+            body: _('80% Charged'),
+            icon: Gio.ThemedIcon.new('battery-full-charged-symbolic'),
+            buttons: buttons,
+        });
+    }
     /**
      * Notify the user the remote battery is low.
      */
@@ -302,6 +357,18 @@ var Plugin = GObject.registerClass({
             // If the level is above the threshold hide the notification
             if (this._level > this._thresholdLevel)
                 this.device.hideNotification('battery|low');
+
+            // The level just changed to/from 60%
+            if (this._level === 60)
+                this._sixtyBatteryNotification();
+            else
+                this.device.hideNotification('battery|sixty');
+            
+            // The level just changed to/from 80%
+            if (this._level === 80)
+                this._eightyBatteryNotification();
+            else
+                this.device.hideNotification('battery|eighty');
 
             // The level just changed to/from full
             if (this._level === 100)


### PR DESCRIPTION
#872 
I added two toggles for 60% and 80% battery level notifications while device is charging. Testing was done on my laptop, ASUS FA506IV running Pop!_OS 20.04, connecting to my Pixel 3A running GrapheneOS. Virtual Pixel 3A using genymotion was also functional.

I attempted to add a slider or spinbutton to add a custom charge level, but could not figure out how to make it work. Glade kept breaking the UI files just by opening them, and I couldn't find a slider or spinbutton in the repo that I could copy.

If someone could give me some pointers on how to implement a custom level, I'd greatly appreciate it, as that would be much more useful. I could not get the schema to accept a key with an integer type, nor could I get the spinbutton or the slider to update the key value. I had been editing the UI files by hand, but I assume that there is a better method, as all the documentation I could find either uses Glade or compiles them.