### PR TITLE
Service UI: fix device selector

### DIFF
--- a/src/service/ui/service.js
+++ b/src/service/ui/service.js
@@ -119,7 +119,7 @@ var DeviceChooser = GObject.registerClass({
         // Collect known devices
         const devices = {};
 
-        for (const [id, device] of this.application.devices.entries())
+        for (const [id, device] of this.application.manager.devices.entries())
             devices[id] = device;
 
         // Prune device rows


### PR DESCRIPTION
The device selector was not updated to use the device manager as a
source for devices.

closes #1041