### PR TITLE
RunCommand Plugin: fix commandList serializing/deserializing

### DIFF
--- a/installed-tests/suites/plugins/testRuncommandPlugin.js
+++ b/installed-tests/suites/plugins/testRuncommandPlugin.js
@@ -87,12 +87,7 @@ describe('The runcommand plugin', function () {
         localPlugin.settings.set_value('command-list', commandList);
 
         await remotePlugin.awaitPacket('kdeconnect.runcommand', {
-            commandList: {
-                'command-uuid': {
-                    name: 'Test Command',
-                    command: 'ls',
-                },
-            },
+            commandList: '{"command-uuid":{"name":"Test Command","command":"ls"}}',
         });
 
         expect(remotePlugin.remote_commands['command-uuid']).toBeDefined();

--- a/src/service/plugins/runcommand.js
+++ b/src/service/plugins/runcommand.js
@@ -147,9 +147,18 @@ var Plugin = GObject.registerClass({
      * Parse the response to a request for the remote command list. Remove the
      * command menu if there are no commands, otherwise amend the menu.
      *
-     * @param {Object[]} commandList - A list of remote commands
+     * @param {string|Object[]} commandList - A list of remote commands
      */
     _handleCommandList(commandList) {
+        // See: https://github.com/GSConnect/gnome-shell-extension-gsconnect/issues/1051
+        if (typeof commandList === 'string') {
+            try {
+                commandList = JSON.parse(commandList);
+            } catch (e) {
+                commandList = {};
+            }
+        }
+
         this._remote_commands = commandList;
         this.notify('remote-commands');
 
@@ -207,10 +216,11 @@ var Plugin = GObject.registerClass({
      */
     _sendCommandList() {
         const commands = this.settings.get_value('command-list').recursiveUnpack();
+        const commandList = JSON.stringify(commands);
 
         this.device.sendPacket({
             type: 'kdeconnect.runcommand',
-            body: {commandList: commands},
+            body: {commandList: commandList},
         });
     }
 


### PR DESCRIPTION
Apparently the `commandList` object is supposed to be a serialized JSON
string.

closes #1051