### PR TITLE
WIP: Allow controlling volume for remote players using MPRIS

### DIFF
--- a/src/service/plugins/mpris.js
+++ b/src/service/plugins/mpris.js
@@ -734,6 +734,13 @@ const PlayerRemote = GObject.registerClass({
         return 'Stopped';
     }
 
+    get Volume() {
+        if (this._Volume === undefined)
+            this._Volume = 0.3;
+
+        return this._Volume;
+    }
+
     set Volume(level) {
         if (this._Volume === level)
             return;

--- a/src/service/plugins/mpris.js
+++ b/src/service/plugins/mpris.js
@@ -745,7 +745,7 @@ const PlayerRemote = GObject.registerClass({
             type: 'kdeconnect.mpris.request',
             body: {
                 player: this.Identity,
-                setVolume: Math.floor(this.Volume * 100),
+                setVolume: Math.floor(this._Volume * 100),
             },
         });
     }


### PR DESCRIPTION
Changed 'Volume' which didnt exist to '_Volume'. This is the volume being
set / sent out by mpris which we want to convert and send to intended
device. This should fix Volume changes not being sent and causing volume
to spike to 100 (at least on KDEConnect Android app).


This fixes #1067 