### PR TITLE
Fix compatibility with GJS 1.68

### DIFF
--- a/installed-tests/fixtures/backend.js
+++ b/installed-tests/fixtures/backend.js
@@ -27,7 +27,7 @@ var ChannelService = GObject.registerClass({
             'port',
             'Port',
             'The port used by the service',
-            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+            GObject.ParamFlags.READWRITE,
             0,  GLib.MAXUINT16,
             DEFAULT_PORT
         ),

--- a/src/preferences/device.js
+++ b/src/preferences/device.js
@@ -249,7 +249,7 @@ var Panel = GObject.registerClass({
             'device',
             'Device',
             'The device being configured',
-            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+            GObject.ParamFlags.READWRITE,
             GObject.Object.$gtype
         ),
     },

--- a/src/service/backends/lan.js
+++ b/src/service/backends/lan.js
@@ -79,14 +79,14 @@ var ChannelService = GObject.registerClass({
             'certificate',
             'Certificate',
             'The TLS certificate',
-            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+            GObject.ParamFlags.READWRITE,
             Gio.TlsCertificate.$gtype
         ),
         'port': GObject.ParamSpec.uint(
             'port',
             'Port',
             'The port used by the service',
-            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+            GObject.ParamFlags.READWRITE,
             0,  GLib.MAXUINT16,
             DEFAULT_PORT
         ),

--- a/src/service/core.js
+++ b/src/service/core.js
@@ -330,7 +330,7 @@ var ChannelService = GObject.registerClass({
             'id',
             'ID',
             'The hostname or other network unique id',
-            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+            GObject.ParamFlags.READWRITE,
             null
         ),
         'name': GObject.ParamSpec.string(
@@ -480,7 +480,7 @@ var Transfer = GObject.registerClass({
             'channel',
             'Channel',
             'The channel that owns this transfer',
-            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+            GObject.ParamFlags.READWRITE,
             Channel.$gtype
         ),
         'completed': GObject.ParamSpec.boolean(
@@ -494,7 +494,7 @@ var Transfer = GObject.registerClass({
             'device',
             'Device',
             'The device that created this transfer',
-            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+            GObject.ParamFlags.READWRITE,
             GObject.Object.$gtype
         ),
     },

--- a/src/service/plugins/findmyphone.js
+++ b/src/service/plugins/findmyphone.js
@@ -127,14 +127,14 @@ const Dialog = GObject.registerClass({
             'device',
             'Device',
             'The device associated with this window',
-            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+            GObject.ParamFlags.READWRITE,
             GObject.Object
         ),
         'plugin': GObject.ParamSpec.object(
             'plugin',
             'Plugin',
             'The plugin providing messages',
-            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+            GObject.ParamFlags.READWRITE,
             GObject.Object
         ),
     },

--- a/src/service/ui/contacts.js
+++ b/src/service/ui/contacts.js
@@ -366,7 +366,7 @@ var ContactChooser = GObject.registerClass({
             'device',
             'Device',
             'The device associated with this window',
-            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+            GObject.ParamFlags.READWRITE,
             GObject.Object
         ),
         'store': GObject.ParamSpec.object(

--- a/src/service/ui/legacyMessaging.js
+++ b/src/service/ui/legacyMessaging.js
@@ -16,14 +16,14 @@ var Dialog = GObject.registerClass({
             'device',
             'Device',
             'The device associated with this window',
-            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+            GObject.ParamFlags.READWRITE,
             GObject.Object
         ),
         'plugin': GObject.ParamSpec.object(
             'plugin',
             'Plugin',
             'The plugin providing messages',
-            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+            GObject.ParamFlags.READWRITE,
             GObject.Object
         ),
     },

--- a/src/service/ui/messaging.js
+++ b/src/service/ui/messaging.js
@@ -273,14 +273,14 @@ const Conversation = GObject.registerClass({
             'device',
             'Device',
             'The device associated with this conversation',
-            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+            GObject.ParamFlags.READWRITE,
             GObject.Object
         ),
         'plugin': GObject.ParamSpec.object(
             'plugin',
             'Plugin',
             'The plugin providing this conversation',
-            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+            GObject.ParamFlags.READWRITE,
             GObject.Object
         ),
         'has-pending': GObject.ParamSpec.boolean(
@@ -294,7 +294,7 @@ const Conversation = GObject.registerClass({
             'thread-id',
             'Thread ID',
             'The current thread',
-            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+            GObject.ParamFlags.READWRITE,
             ''
         ),
     },
@@ -799,14 +799,14 @@ var Window = GObject.registerClass({
             'device',
             'Device',
             'The device associated with this window',
-            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+            GObject.ParamFlags.READWRITE,
             GObject.Object
         ),
         'plugin': GObject.ParamSpec.object(
             'plugin',
             'Plugin',
             'The plugin providing messages',
-            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+            GObject.ParamFlags.READWRITE,
             GObject.Object
         ),
         'thread-id': GObject.ParamSpec.string(
@@ -1218,7 +1218,7 @@ var ConversationChooser = GObject.registerClass({
             'device',
             'Device',
             'The device associated with this window',
-            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+            GObject.ParamFlags.READWRITE,
             GObject.Object
         ),
         'message': GObject.ParamSpec.string(
@@ -1232,7 +1232,7 @@ var ConversationChooser = GObject.registerClass({
             'plugin',
             'Plugin',
             'The plugin providing messages',
-            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+            GObject.ParamFlags.READWRITE,
             GObject.Object
         ),
     },

--- a/src/service/ui/mousepad.js
+++ b/src/service/ui/mousepad.js
@@ -75,14 +75,14 @@ var InputDialog = GObject.registerClass({
             'device',
             'Device',
             'The device associated with this window',
-            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+            GObject.ParamFlags.READWRITE,
             GObject.Object
         ),
         'plugin': GObject.ParamSpec.object(
             'plugin',
             'Plugin',
             'The mousepad plugin associated with this window',
-            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+            GObject.ParamFlags.READWRITE,
             GObject.Object
         ),
     },

--- a/src/service/ui/notification.js
+++ b/src/service/ui/notification.js
@@ -17,21 +17,21 @@ var ReplyDialog = GObject.registerClass({
             'device',
             'Device',
             'The device associated with this window',
-            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+            GObject.ParamFlags.READWRITE,
             GObject.Object
         ),
         'plugin': GObject.ParamSpec.object(
             'plugin',
             'Plugin',
             'The plugin that owns this notification',
-            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+            GObject.ParamFlags.READWRITE,
             GObject.Object
         ),
         'uuid': GObject.ParamSpec.string(
             'uuid',
             'UUID',
             'The notification reply UUID',
-            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+            GObject.ParamFlags.READWRITE,
             null
         ),
     },

--- a/src/service/utils/dbus.js
+++ b/src/service/utils/dbus.js
@@ -43,7 +43,7 @@ var Interface = GObject.registerClass({
             'g-instance',
             'Instance',
             'The delegate GObject',
-            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+            GObject.ParamFlags.READWRITE,
             GObject.Object.$gtype
         ),
     },


### PR DESCRIPTION
Fixes: https://github.com/GSConnect/gnome-shell-extension-gsconnect/issues/1073
Fixes: https://github.com/GSConnect/gnome-shell-extension-gsconnect/issues/1071

Related to this change in GJS: https://gitlab.gnome.org/GNOME/gjs/-/merge_requests/591/

Parameters with CONSTRUCT_ONLY flag set seem to work differently now, or maybe
are just broken :shrug: