### PR TITLE
mpris: Initialize conditional fields for requestNowPlaying response

### DIFF
--- a/src/service/plugins/mpris.js
+++ b/src/service/plugins/mpris.js
@@ -259,6 +259,15 @@ var Plugin = GObject.registerClass({
                     canGoNext: player.CanGoNext,
                     canGoPrevious: player.CanGoPrevious,
                     canSeek: player.CanSeek,
+
+                    // default values for members that will be filled conditionally
+                    albumArtUrl: '',
+                    length: 0,
+                    artist: '',
+                    title: '',
+                    album: '',
+                    nowPlaying: '',
+                    volume: 0,
                 });
 
                 const metadata = player.Metadata;


### PR DESCRIPTION
This fixes an issue where previous song metadata is not fully
zeroed-out after song changed.

Test: Play song with cover art then switch to one without it,
        observe that on kde-connect-android you still see previous
        song's cover art.