### PR TITLE
UI: revert gtk3->gtk4 functions

### DIFF
--- a/src/preferences/device.js
+++ b/src/preferences/device.js
@@ -383,7 +383,7 @@ var Panel = GObject.registerClass({
             text: _('Encryption Info'),
             secondary_text: this.device.encryption_info,
             modal: true,
-            transient_for: this.get_root(),
+            transient_for: this.get_toplevel(),
         });
         dialog.connect('response', (dialog) => dialog.destroy());
         dialog.present();
@@ -683,7 +683,7 @@ var Panel = GObject.registerClass({
         if (this._commandEditor === undefined) {
             this._commandEditor = new CommandEditor({
                 modal: true,
-                transient_for: this.get_root(),
+                transient_for: this.get_toplevel(),
                 use_header_bar: true,
             });
 

--- a/src/service/ui/legacyMessaging.js
+++ b/src/service/ui/legacyMessaging.js
@@ -186,7 +186,7 @@ var Dialog = GObject.registerClass({
 
     _onActivateLink(label, uri) {
         Gtk.show_uri_on_window(
-            this.get_root(),
+            this.get_toplevel(),
             uri.includes('://') ? uri : `https://${uri}`,
             Gtk.get_current_event_time()
         );

--- a/src/service/ui/messaging.js
+++ b/src/service/ui/messaging.js
@@ -234,7 +234,7 @@ const ConversationMessage = GObject.registerClass({
 
     _onActivateLink(label, uri) {
         Gtk.show_uri_on_window(
-            this.get_root(),
+            this.get_toplevel(),
             uri.includes('://') ? uri : `https://${uri}`,
             Gtk.get_current_event_time()
         );

--- a/src/service/ui/notification.js
+++ b/src/service/ui/notification.js
@@ -156,7 +156,7 @@ var ReplyDialog = GObject.registerClass({
 
     _onActivateLink(label, uri) {
         Gtk.show_uri_on_window(
-            this.get_root(),
+            this.get_toplevel(),
             uri.includes('://') ? uri : `https://${uri}`,
             Gtk.get_current_event_time()
         );


### PR DESCRIPTION
These were wrapped by a compatibility script previously, but should be
Gtk3 functions, not Gtk4.

fixes #1095