### PR TITLE
v47

### DIFF
--- a/data/metainfo/org.gnome.Shell.Extensions.GSConnect.metainfo.xml.in
+++ b/data/metainfo/org.gnome.Shell.Extensions.GSConnect.metainfo.xml.in
@@ -49,6 +49,9 @@
   </description>
 
   <releases>
+    <release version="47" date="2021-06-18">
+      <url>https://github.com/andyholmes/gnome-shell-extension-gsconnect/releases/tag/v47</url>
+    </release>
     <release version="46" date="2021-03-29">
       <url>https://github.com/andyholmes/gnome-shell-extension-gsconnect/releases/tag/v46</url>
     </release>

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('gsconnect',
   'c',
-  version: '46',
+  version: '47',
   meson_version: '>= 0.46.0'
 )
 

--- a/src/gsconnect-preferences
+++ b/src/gsconnect-preferences
@@ -1,5 +1,7 @@
 #!/usr/bin/env gjs
 
+// -*- mode: js; -*-
+
 'use strict';
 
 imports.gi.versions.Gdk = '3.0';


### PR DESCRIPTION
ClipboardComponent test `pushes changes to the session clipboard` is failing on my computer.

```
 9/26 gsconnect:components / ClipboardComponent            ERROR          5.16s

--- command ---
21:14:15 NO_AT_BRIDGE='1' G_DEBUG='fatal-warnings,fatal-criticals' GSETTINGS_SCHEMA_DIR='/home/sonny/Projects/GNOME/gnome-shell-extension-gsconnect/_build/installed-tests' GJS_PATH='/home/sonny/Projects/GNOME/gnome-shell-extension-gsconnect/_build/installed-tests/src' GSCONNECT_TEST='1' GSETTINGS_BACKEND='memory' /home/sonny/Projects/GNOME/gnome-shell-extension-gsconnect/installed-tests/minijasmine /home/sonny/Projects/GNOME/gnome-shell-extension-gsconnect/_build/../installed-tests/suites/components/testClipboardComponent.js
--- stdout ---
1..2
ok 1 The Clipboard component pulls changes from the session clipboard
not ok 2 The Clipboard component pushes changes to the session clipboard
# Message: Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL) in /home/sonny/Projects/GNOME/gnome-shell-extension-gsconnect/installed-tests/jasmine.js (line 7049)
# Stack:
#   error properties: Object({ matches: Function })
--- stderr ---

(test program exited with status code 1)
-------
```