### PR TITLE
Expose LoopStatus and Shuffle control to clients

### DIFF
--- a/src/service/plugins/mpris.js
+++ b/src/service/plugins/mpris.js
@@ -228,6 +228,12 @@ var Plugin = GObject.registerClass({
             }
 
             // Player Properties
+            if (packet.body.hasOwnProperty('setLoopStatus'))
+                player.LoopStatus = packet.body.setLoopStatus;
+
+            if (packet.body.hasOwnProperty('setShuffle'))
+                player.Shuffle = packet.body.setShuffle;
+
             if (packet.body.hasOwnProperty('setVolume'))
                 player.Volume = packet.body.setVolume / 100;
 
@@ -260,6 +266,8 @@ var Plugin = GObject.registerClass({
                     canGoNext: player.CanGoNext,
                     canGoPrevious: player.CanGoPrevious,
                     canSeek: player.CanSeek,
+                    loopStatus: player.LoopStatus,
+                    shuffle: player.Shuffle,
 
                     // default values for members that will be filled conditionally
                     albumArtUrl: '',


### PR DESCRIPTION
This change follows KDE Connect change merged here:
https://invent.kde.org/network/kdeconnect-kde/-/merge_requests/401