### PR TITLE
Update nautilus-gsconnect.py

### DIFF
--- a/nautilus-extension/nautilus-gsconnect.py
+++ b/nautilus-extension/nautilus-gsconnect.py
@@ -125,6 +125,8 @@ class GSConnectShareExtension(GObject.Object, FileManager.MenuProvider):
 
         for object_path, props in objects.items():
             props = props['org.gnome.Shell.Extensions.GSConnect.Device']
+            if not props:
+                continue
 
             self.devices[object_path] = (props['Name'],
                                          Gio.DBusActionGroup.get(


### PR DESCRIPTION
When I was restarting nautilus I noticed this message:

```
GSConnect: No translation file found for domain
Initializing nautilus-dropbox 2019.02.14
Traceback (most recent call last):
  File "/home/stu/.local/share/nautilus-python/extensions/nautilus-gsconnect.py", line 129, in _get_managed_objects
    self.devices[object_path] = (props['Name'],
KeyError: 'Name'
```

This fixes the error as the dict was empty in this case, but not idea if something else breaks.