### PR TITLE
Show SHA256 fingerprints

### DIFF
--- a/src/service/__init__.js
+++ b/src/service/__init__.js
@@ -354,22 +354,22 @@ Gio.TlsCertificate.new_for_paths = function (certPath, keyPath, commonName = nul
 
 Object.defineProperties(Gio.TlsCertificate.prototype, {
     /**
-     * Compute a SHA1 fingerprint of the certificate.
+     * Compute a SHA256 fingerprint of the certificate.
      * See: https://gitlab.gnome.org/GNOME/glib/issues/1290
      *
-     * @return {string} A SHA1 fingerprint of the certificate.
+     * @return {string} A SHA256 fingerprint of the certificate.
      */
-    'fingerprint': {
+    'sha256': {
         value: function () {
             if (!this.__fingerprint) {
                 const proc = new Gio.Subprocess({
-                    argv: [Config.OPENSSL_PATH, 'x509', '-noout', '-fingerprint', '-sha1', '-inform', 'pem'],
+                    argv: [Config.OPENSSL_PATH, 'x509', '-noout', '-fingerprint', '-sha256', '-inform', 'pem'],
                     flags: Gio.SubprocessFlags.STDIN_PIPE | Gio.SubprocessFlags.STDOUT_PIPE,
                 });
                 proc.init(null);
 
                 const stdout = proc.communicate_utf8(this.certificate_pem, null)[1];
-                this.__fingerprint = /[a-zA-Z0-9:]{59}/.exec(stdout)[0];
+                this.__fingerprint = /[a-zA-Z0-9:]{95}/.exec(stdout)[0];
             }
 
             return this.__fingerprint;

--- a/src/service/device.js
+++ b/src/service/device.js
@@ -169,14 +169,14 @@ var Device = GObject.registerClass({
 
         // If the device is connected use the certificate from the connection
         } else if (this.connected) {
-            remoteFingerprint = this.channel.peer_certificate.fingerprint();
+            remoteFingerprint = this.channel.peer_certificate.sha256();
 
         // Otherwise pull it out of the settings
         } else if (this.paired) {
             remoteFingerprint = Gio.TlsCertificate.new_from_pem(
                 this.settings.get_string('certificate-pem'),
                 -1
-            ).fingerprint();
+            ).sha256();
         }
 
         // FIXME: another ugly reach-around
@@ -186,7 +186,7 @@ var Device = GObject.registerClass({
             lanBackend = this.service.manager.backends.get('lan');
 
         if (lanBackend && lanBackend.certificate)
-            localFingerprint = lanBackend.certificate.fingerprint();
+            localFingerprint = lanBackend.certificate.sha256();
 
         // TRANSLATORS: Label for TLS Certificate fingerprint
         //


### PR DESCRIPTION
I changed the monkeypatched function name to improve code clarity (being unfamiliar with the codebase, it was unclear to me at the call sites what kind of fingerprint the function returned) and also to avoid clashing with future GLib APIs.

Ref #1091