### PR TITLE
CI: show error logs during linting step

### DIFF
--- a/.github/workflows/gnome-3-36.yml
+++ b/.github/workflows/gnome-3-36.yml
@@ -24,7 +24,8 @@ jobs:
       - name: Uninstalled Tests
         run: |
           meson test -C _build --suite gsconnect:data \
-                               --suite gsconnect:lint
+                               --suite gsconnect:lint \
+                               --print-errorlogs
 
       - name: Installed Tests
         run: |

--- a/.github/workflows/gnome-3-38.yml
+++ b/.github/workflows/gnome-3-38.yml
@@ -24,7 +24,8 @@ jobs:
       - name: Uninstalled Tests
         run: |
           meson test -C _build --suite gsconnect:data \
-                               --suite gsconnect:lint
+                               --suite gsconnect:lint \
+                               --print-errorlogs
 
       - name: Installed Tests
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,8 @@ jobs:
       - name: Uninstalled Tests
         run: |
           meson test -C _build --suite gsconnect:data \
-                               --suite gsconnect:lint
+                               --suite gsconnect:lint \
+                               --print-errorlogs
 
       - name: Installed Tests
         run: |


### PR DESCRIPTION
Show linter errors in the CI output so contributors don't need to
download a ZIP of log files just to fix code-style problems.