### PR TITLE
Lan: make transfers more lenient

### DIFF
--- a/src/service/backends/lan.js
+++ b/src/service/backends/lan.js
@@ -859,11 +859,20 @@ var Channel = GObject.registerClass({
         // Start the transfer
         const transferredSize = await this._transfer(source, target, cancellable);
 
-        if (transferredSize !== packet.payloadSize) {
+        // If we get less than expected, we've certainly got corruption
+        if (transferredSize < packet.payloadSize) {
             throw new Gio.IOErrorEnum({
-                code: Gio.IOErrorEnum.PARTIAL_INPUT,
-                message: 'Transfer incomplete',
+                code: Gio.IOErrorEnum.FAILED,
+                message: `Incomplete: ${transferredSize}/${packet.payloadSize}`,
             });
+
+        // TODO: sometimes kdeconnect-android under-reports a file's size
+        //       https://github.com/GSConnect/gnome-shell-extension-gsconnect/issues/1157
+        } else if (transferredSize > packet.payloadSize) {
+            logError(new Gio.IOErrorEnum({
+                code: Gio.IOErrorEnum.FAILED,
+                message: `Extra Data: ${transferredSize - packet.payloadSize}`,
+            }));
         }
     }
 


### PR DESCRIPTION
If a we receive less than the expected amount of data from a transfer,
we most certainly have corruption. However kdeconnect-android sometimes
unreports a file's size in the payload info.

In that case we will only log a warning and let the user decide if the
file is corrupted when they try to open it. Even though there is a clear
opportunity for abuse, this should not be a security risk because the
device has already passed pairing.

closes #1157