### PR TITLE
MousePad Plugin: add abilities to receive a string as a set of key input

### DIFF
--- a/src/service/plugins/mousepad.js
+++ b/src/service/plugins/mousepad.js
@@ -186,7 +186,13 @@ var Plugin = GObject.registerClass({
 
                 // Regular key (printable ASCII or Unicode)
                 if (input.key) {
-                    this._input.pressKey(input.key, modifiers);
+                    if( typeof input.key === 'string' ) {
+                        for (var i = 0; i < input.key.length; i++) {
+                            this._input.pressKey(input.key.charAt(i), modifiers);
+                        }
+                    } else {
+                        this._input.pressKey(input.key, modifiers);
+                    }
                     this._sendEcho(input);
 
                 // Special key (eg. non-printable ASCII)


### PR DESCRIPTION
from the code implemented in KDEConnect Android (KeyListenerView.java) or
in KDEConnect (windowsremoteinput.cpp or x11remoteinput.cpp) the value
associated the "key" property of a network packet can contains multiple
charaters.