### PR TITLE
RunCommand Plugin: fix menu item replacement

### DIFF
--- a/src/service/plugins/runcommand.js
+++ b/src/service/plugins/runcommand.js
@@ -197,7 +197,7 @@ var Plugin = GObject.registerClass({
         const index = menuActions.indexOf('commands');
 
         if (index > -1) {
-            this.device.removeMenuAction('commands');
+            this.device.removeMenuAction('device.commands');
             this.device.addMenuItem(item, index);
         }
     }


### PR DESCRIPTION
When the menu item was being removed, the action name wasn't prefixed
with the scope (eg. `device.commands`), resulting in an infinite amount
of invisible menu items being exported over D-Bus.

fixes #1028