### PR TITLE
Remove all files when disabling extension

### DIFF
--- a/data/metadata.json.in
+++ b/data/metadata.json.in
@@ -4,5 +4,6 @@
     "description": "GSConnect is a complete implementation of KDE Connect especially for GNOME Shell with Nautilus, Chrome and Firefox integration. It does not rely on the KDE Connect desktop application and will not work with it installed.\n\nKDE Connect allows devices to securely share content like notifications or files and other features like SMS messaging and remote control. The KDE Connect team has applications for Linux, BSD, Android, Sailfish and Windows.\n\nPlease report issues on Github!",
     "version": @PACKAGE_VERSION@,
     "shell-version": [ "41" ],
-    "url": "@PACKAGE_URL@/wiki"
+    "url": "@PACKAGE_URL@/wiki",
+    "session-modes": ["user", "unlock-dialog"],
 }

--- a/src/extension.js
+++ b/src/extension.js
@@ -423,12 +423,6 @@ var serviceIndicator = null;
 
 
 function init() {
-    // If installed as a user extension, this will install the Desktop entry,
-    // DBus and systemd service files necessary for DBus activation and
-    // GNotifications. Since there's no uninit()/uninstall() hook for extensions
-    // and they're only used *by* GSConnect, they should be okay to leave.
-    Utils.installService();
-
     // These modify the notification source for GSConnect's GNotifications and
     // need to be active even when the extension is disabled (eg. lock screen).
     // Since they *only* affect notifications from GSConnect, it should be okay
@@ -443,6 +437,10 @@ function init() {
 
 
 function enable() {
+    // If installed as a user extension, this will install the Desktop entry,
+    // DBus and systemd service files necessary for DBus activation and
+    // GNotifications.
+    Utils.installService(true);
     serviceIndicator = new ServiceIndicator();
     Notification.patchGtkNotificationSources();
 }
@@ -452,4 +450,5 @@ function disable() {
     serviceIndicator.destroy();
     serviceIndicator = null;
     Notification.unpatchGtkNotificationSources();
+    Utils.installService(false);
 }

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -9,7 +9,7 @@ const Extension = imports.misc.extensionUtils.getCurrentExtension();
 const Utils = Extension.imports.shell.utils;
 
 function init() {
-    Utils.installService();
+    Utils.installService(true);
 }
 
 function buildPrefsWidget() {

--- a/src/shell/utils.js
+++ b/src/shell/utils.js
@@ -128,7 +128,7 @@ function _installResource(dirname, basename, relativePath) {
 /**
  * Install the files necessary for the GSConnect service to run.
  */
-function installService() {
+function installService(enabling) {
     const confDir = GLib.get_user_config_dir();
     const dataDir = GLib.get_user_data_dir();
     const homeDir = GLib.get_home_dir();
@@ -171,7 +171,7 @@ function installService() {
 
     // If running as a user extension, ensure the DBus service, desktop entry,
     // file manager scripts, and WebExtension manifests are installed.
-    if (Config.IS_USER) {
+    if (Config.IS_USER && enabling) {
         // DBus Service
         if (!_installResource(dbusDir, dbusFile, `${dbusFile}.in`))
             throw Error('GSConnect: Failed to install DBus Service');


### PR DESCRIPTION
If the extension is uninstalled, the DBus file and others
remain in the system. This can cause problems to other programs
that interact with GSConnect.

This patch fixes this issue by removing all the files when the
extension is disabled, and recreating them when it is enabled.

Fix https://github.com/GSConnect/gnome-shell-extension-gsconnect/issues/1269