### PR TITLE
Protect against empty SMS address values

### DIFF
--- a/src/service/__init__.js
+++ b/src/service/__init__.js
@@ -167,7 +167,7 @@ String.prototype.equalsPhoneNumber = function (number) {
     const a = this.toPhoneNumber();
     const b = number.toPhoneNumber();
 
-    return (a.endsWith(b) || b.endsWith(a));
+    return (a.length && b.length && (a.endsWith(b) || b.endsWith(a)));
 };
 
 

--- a/src/service/plugins/sms.js
+++ b/src/service/plugins/sms.js
@@ -100,13 +100,18 @@ var MessageStatus = {
 
 
 /**
- * SMS Message direction. IN/OUT match the 'type' field from the Android App
+ * SMS Message type, set from the 'type' field in the Android App
  * message packet.
  *
  * See: https://developer.android.com/reference/android/provider/Telephony.TextBasedSmsColumns.html
  *
- * IN: An incoming message
- * OUT: An outgoing message
+ * ALL: all messages
+ * INBOX: Received messages
+ * SENT: Sent messages
+ * DRAFT: Message drafts
+ * OUTBOX: Outgoing messages
+ * FAILED: Failed outgoing messages
+ * QUEUED: Messages queued to send later
  */
 var MessageBox = {
     ALL: 0,

--- a/src/service/ui/messaging.js
+++ b/src/service/ui/messaging.js
@@ -374,10 +374,13 @@ const Conversation = GObject.registerClass({
             // Get corrected address
             let number = address.toPhoneNumber();
 
+            if (!number)
+                continue;
+
             for (const contactNumber of contact.numbers) {
                 const cnumber = contactNumber.value.toPhoneNumber();
 
-                if (number.endsWith(cnumber) || cnumber.endsWith(number)) {
+                if (cnumber && (number.endsWith(cnumber) || cnumber.endsWith(number))) {
                     number = contactNumber.value;
                     break;
                 }


### PR DESCRIPTION
As the branch name indicates, this started out as a quick update to the docstring for `MessageBox` in the sms plugin, since it failed to document any of the current values.

But then I discovered that I was having a problem with contact matching on my system, because one of my contacts has an _empty_ phone number listed. That number was therefore matching basically _**every**_ address that came over the wire, since the test for matching just used `foo.endsWith(bar)` as the condition, and everything ends with `""`.

So, the real meat of this PR is the second commit, which first sanity-checks that neither string being matched is empty before testing for address matches. WorksForMe™, in repairing my Messaging window's ability to identify the participants in SMS conversations.