### PR TITLE
CI: Fix typeof-typo in test fixture

### DIFF
--- a/installed-tests/fixtures/utils.js
+++ b/installed-tests/fixtures/utils.js
@@ -136,7 +136,7 @@ function isSubset(obj, subset) {
             return false;
 
         // We were only checking for the key itself
-        if (typeof val === undefined)
+        if (typeof val === 'undefined')
             continue;
 
         if (Array.isArray(val)) {


### PR DESCRIPTION
A small typo makes the `installed-tests` un-passable.