### PR TITLE
Presenter Plugin: fix handling of specialKey in input

### DIFF
--- a/src/service/components/input.js
+++ b/src/service/components/input.js
@@ -609,8 +609,12 @@ class Controller {
         try {
             this._ensureAdapter();
 
-            for (let i = 0; i < input.length; i++)
-                this._session.pressKey(input[i], modifiers);
+            if (typeof input === 'string') {
+                for (let i = 0; i < input.length; i++)
+                    this._session.pressKey(input[i], modifiers);
+            } else {
+                this._session.pressKey(input, modifiers);
+            }
         } catch (e) {
             debug(e);
         }


### PR DESCRIPTION
Fix passing key symbols (ie. `Number`) to a function expecting a character or string of characters.

Fixes #1341