### PR TITLE
WIP: Initial Bluetooth handoff impl

### DIFF
--- a/data/org.gnome.Shell.Extensions.GSConnect.gresource.xml
+++ b/data/org.gnome.Shell.Extensions.GSConnect.gresource.xml
@@ -11,6 +11,8 @@
     <file compressed="true" preprocess="xml-stripblanks">ui/messaging-conversation-summary.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/messaging-conversation.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/messaging-window.ui</file>
+    <file compressed="true" preprocess="xml-stripblanks">ui/bluetooth-handoff-dialog.ui</file>
+    <file compressed="true" preprocess="xml-stripblanks">ui/bluetooth-handoff-device-row.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/mousepad-input-dialog.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/notification-reply-dialog.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">ui/preferences-command-editor.ui</file>

--- a/data/org.gnome.Shell.Extensions.GSConnect.gschema.xml
+++ b/data/org.gnome.Shell.Extensions.GSConnect.gschema.xml
@@ -46,7 +46,7 @@
       <default>{}</default>
     </key>
     <key name="menu-actions" type="as">
-      <default>["sms", "ring", "mount", "commands", "share", "photo", "keyboard"]</default>
+      <default>["sms", "ring", "mount", "commands", "share", "photo", "keyboard", "openBluetoothHandoffDialog"]</default>
     </key>
     <key name="name" type="s">
       <default>""</default>

--- a/data/ui/bluetooth-handoff-device-row.ui
+++ b/data/ui/bluetooth-handoff-device-row.ui
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface domain="org.gnome.Shell.Extensions.GSConnect">
+  <requires lib="gtk+" version="3.24"/>
+  <template class="GSConnectBluetoothHandoffDeviceRow" parent="GtkListBoxRow">
+    <property name="visible">True</property>
+    <property name="hexpand">True</property>
+    <property name="can_focus">False</property>
+    <property name="selectable">False</property>
+    <property name="activatable">True</property>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="border-width">12</property>
+        <property name="margin_left">6</property>
+        <property name="margin_right">6</property>
+        <property name="orientation">horizontal</property>
+        <child>
+          <object class="GtkImage" id="device_icon">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="valign">center</property>
+            <property name="margin_right">12</property>
+            <property name="icon_name">bluetooth-active-symbolic</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="device_name">
+            <property name="visible">True</property>
+            <property name="hexpand">True</property>
+            <property name="label"></property>
+            <property name="xalign">0.0</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkSwitch" id="switch">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="valign">center</property>
+            <signal name="state-set" handler="_onDeviceToggled" swapped="no"/>
+          </object>
+        </child>
+      </object>
+    </child>
+  </template>
+</interface>
+

--- a/data/ui/bluetooth-handoff-dialog.ui
+++ b/data/ui/bluetooth-handoff-dialog.ui
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <requires lib="gtk+" version="3.24"/>
+  <template class="GSConnectBluetoothHandoffDialog" parent="GtkDialog">
+    <property name="can_focus">False</property>
+    <property name="default_width">500</property>
+    <property name="default_height">400</property>
+    <property name="type_hint">dialog</property>
+    <child internal-child="vbox">
+      <object class="GtkBox">
+        <property name="can_focus">False</property>
+        <property name="margin_left">36</property>
+        <property name="margin_right">36</property>
+        <property name="margin_top">24</property>
+        <property name="margin_bottom">24</property>
+        <property name="orientation">vertical</property>
+        <property name="visible">True</property>
+        <child>
+          <object class="GtkListBox" id="device_list">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="visible">True</property>
+            <property name="margin_bottom">18</property>
+            <property name="selection-mode">none</property>
+            <style>
+              <class name="frame"/>
+            </style>
+            <child type="placeholder">
+              <object class="GtkListBoxRow">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="selectable">False</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="margin_top">12</property>
+                    <property name="margin_bottom">12</property>
+                    <property name="margin_left">12</property>
+                    <property name="margin_right">12</property>
+                    <property name="label" translatable="yes">No Devices</property>
+                    <style>
+                      <class name="dim-label"/>
+                    </style>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="instruction-label">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="wrap">True</property>
+          </object>
+        </child>
+      </object>
+    </child>
+  </template>
+</interface>
+

--- a/src/service/components/bluez.js
+++ b/src/service/components/bluez.js
@@ -1,0 +1,188 @@
+'use strict';
+
+const Gio = imports.gi.Gio;
+const GLib = imports.gi.GLib;
+const GObject = imports.gi.GObject;
+
+function log(message) {
+    GLib.log_structured('GSConnect', GLib.LogLevelFlags.LEVEL_MESSAGE, {
+        'MESSAGE': message,
+        'SYSLOG_IDENTIFIER': 'org.gnome.Shell.Extensions.GSConnect.BluetoothHandoff'
+    });
+}
+
+/**
+ * A class representing the local bluetooth devices.
+ */
+var LocalBluetoothDevices = GObject.registerClass({
+    GTypeName: 'GSConnectLocalBluetoothDevices',
+    Signals: {
+        'changed': {
+            flags: GObject.SignalFlags.RUN_FIRST,
+        },
+    },
+}, class LocalBluetoothDevices extends GObject.Object {
+
+    _init() {
+        try {
+            super._init();
+
+            this._cancellable = new Gio.Cancellable();
+            this._proxy = null;
+            this._propertiesChangedId = 0;
+            this._localDevices = {};
+            this._localDevicesJson = "{}";
+
+            this._loadBluez();
+        } catch (e) {
+            log("bluez ERR: " + e.message);
+        }
+    }
+
+    async _loadBluez() {
+        try {
+            this._proxy = new Gio.DBusProxy({
+                g_bus_type: Gio.BusType.SYSTEM,
+                g_name: 'org.bluez',
+                g_object_path: '/',
+                g_interface_name: 'org.freedesktop.DBus.ObjectManager',
+            });
+
+            await new Promise((resolve, reject) => {
+                this._proxy.init_async(
+                    GLib.PRIORITY_DEFAULT,
+                    this._cancellable,
+                    (proxy, res) => {
+                        try {
+                            resolve(proxy.init_finish(res));
+                        } catch (e) {
+                            reject(e);
+                        }
+                    }
+                );
+            });
+
+            this._fetchDevices();
+            GLib.timeout_add(GLib.PRIORITY_DEFAULT, 1000, () => {
+                this._fetchDevices();
+
+                if (!this._cancellable.is_cancelled()) {
+                    return GLib.SOURCE_CONTINUE;
+                } else {
+                    return GLib.SOURCE_REMOVE;
+                }
+            });
+        } catch (e) {
+            log("ERR: " + e.message);
+            this._proxy = null;
+        }
+    }
+
+    async _fetchDevices() {
+        try {
+        let objects = await new Promise((resolve, reject) => {
+            this._proxy.call(
+                'GetManagedObjects',
+                null,
+                Gio.DBusCallFlags.NO_AUTO_START,
+                1000,
+                this._cancellable,
+                (proxy, res) => {
+                    try {
+                        const reply = proxy.call_finish(res);
+                        resolve(reply.deepUnpack()[0]);
+                    } catch (e) {
+                        Gio.DBusError.strip_remote_error(e);
+                        reject(e);
+                    }
+                }
+            );
+        });
+
+        const newLocalDevices = await Promise.all(Object.keys(objects)
+            .filter((rawObjectPath) => {
+                const objectPath = rawObjectPath.split('/');
+                return objectPath.length == 5 && objectPath[0] == '' && objectPath[1] == 'org' && objectPath[2] == 'bluez'
+                    && objectPath[3].startsWith('hci') && objectPath[4].startsWith('dev_');
+            }).map(async (objectPath) => {
+                const objectProxy = new Gio.DBusProxy({
+                    g_bus_type: Gio.BusType.SYSTEM,
+                    g_name: 'org.bluez',
+                    g_object_path: objectPath,
+                    g_interface_name: 'org.bluez.Device1',
+                });
+
+                await new Promise((resolve, reject) => {
+                    objectProxy.init_async(
+                        GLib.PRIORITY_DEFAULT,
+                        null,
+                        (proxy, res) => {
+                            try {
+                                proxy.init_finish(res);
+                                resolve();
+                            } catch (e) {
+                                reject(e);
+                            }
+                        }
+                    );
+                });
+
+                try {
+                    let addr = objectProxy.get_cached_property('Address');
+                    if (addr) addr = addr.recursiveUnpack();
+                    let alias = objectProxy.get_cached_property('Alias');
+                    if (alias) alias = alias.recursiveUnpack();
+                    let name = objectProxy.get_cached_property('Name');
+                    if (name) name = name.recursiveUnpack();
+                    let adapter = objectProxy.get_cached_property('Adapter');
+                    if (adapter) adapter = adapter.recursiveUnpack();
+                    let icon = objectProxy.get_cached_property('Icon');
+                    if (icon) icon = icon.recursiveUnpack();
+                    let paired = objectProxy.get_cached_property('Paired');
+                    if (paired) paired = paired.recursiveUnpack();
+                    let connected = objectProxy.get_cached_property('Connected');
+                    if (connected) connected = connected.recursiveUnpack();
+
+                    return {
+                        addr,
+                        alias,
+                        name,
+                        adapter,
+                        icon,
+                        paired,
+                        connected,
+                    }
+                } catch (e) {
+                    log(" -> err - " + e);
+                }
+            }));
+
+            const newLocalDevicesJson = JSON.stringify(newLocalDevices);
+            if (newLocalDevicesJson != this._localDevicesJson) {
+                this._localDevices = newLocalDevices;
+                this._localDevicesJson = newLocalDevicesJson;
+                this.emit('changed');
+            }
+        } catch (e) {
+            log(" -> err - " + e);
+        }
+    }
+
+    get local_devices() {
+        return this._localDevices;
+    }
+
+    destroy() {
+        if (this._cancellable.is_cancelled())
+            return;
+
+        this._cancellable.cancel();
+    }
+});
+
+
+/**
+ * The service class for this component
+ */
+var Component = LocalBluetoothDevices;
+

--- a/src/service/plugins/bluetooth_handoff.js
+++ b/src/service/plugins/bluetooth_handoff.js
@@ -1,0 +1,287 @@
+'use strict';
+
+const Gio = imports.gi.Gio;
+const GLib = imports.gi.GLib;
+const GObject = imports.gi.GObject;
+
+const Components = imports.service.components;
+const {BluetoothHandoffDialog} = imports.service.ui.bluetoothHandoff;
+const PluginBase = imports.service.plugin;
+
+
+var Metadata = {
+    label: _('Bluetooth Handoff'),
+    description: _('Share Bluetooth devices'),
+    id: 'org.gnome.Shell.Extensions.GSConnect.Plugin.BluetoothHandoff',
+    incomingCapabilities: [
+        'kdeconnect.bluetooth_handoff.device_list',
+        'kdeconnect.bluetooth_handoff.disconnect.response',
+    ],
+    outgoingCapabilities: [
+        'kdeconnect.bluetooth_handoff.device_list.request',
+        'kdeconnect.bluetooth_handoff.disconnect.request',
+    ],
+    actions: {
+        openBluetoothHandoffDialog: {
+            label: _('Bluetooth Devices'),
+            icon_name: 'bluetooth-active-symbolic',
+
+            parameter_type: null,
+            incoming: [],
+            outgoing: ['kdeconnect.bluetooth_handoff.device_list.request'],
+        },
+    },
+};
+
+// TODO: Remove me
+function log(message) {
+    GLib.log_structured('GSConnect', GLib.LogLevelFlags.LEVEL_MESSAGE, {
+        'MESSAGE': message,
+        'SYSLOG_IDENTIFIER': 'org.gnome.Shell.Extensions.GSConnect.BluetoothHandoff'
+    });
+}
+
+
+/**
+ * Bluetooth Handoff Plugin
+ * https://invent.kde.org/network/kdeconnect-kde/-/tree/master/plugins/bluetooth-handoff
+ */
+var Plugin = GObject.registerClass({
+    GTypeName: 'GSConnectBluetoothHandoffPlugin',
+    Signals: {
+        'combined-state-changed': {},
+    },
+}, class Plugin extends PluginBase.Plugin {
+
+    _init(device) {
+        super._init(device, 'bluetooth_handoff');
+
+        this.local_devs_state = [];
+        this.remote_devs_state = [];
+        this.combined_devs_state = [];
+        this.combined_devs_state_json = "[]";
+        this._bluez = null;
+        this._bluezId = 0;
+
+        this._devicePollCancelable = new Gio.Cancellable();
+    }
+
+    connected() {
+        log('Connected');
+        super.connected();
+    }
+
+    handlePacket(packet) {
+        switch (packet.type) {
+            case 'kdeconnect.bluetooth_handoff.device_list':
+                this._receiveRemoteState(packet);
+                break;
+            case 'kdeconnect.bluetooth_handoff.disconnect.response':
+                log('Disconnected: ' + JSON.stringify(packet.body));
+        }
+    }
+
+    openBluetoothHandoffDialog() {
+        log('Open dialog');
+        if (this._dialog === undefined) {
+            this._dialog = new BluetoothHandoffDialog({
+                device: this.device,
+                plugin: this,
+            }, this._dialogClosedCb.bind(this));
+        }
+
+        this._dialog.present();
+
+        // Force update
+        this.combined_devs_state_json = "[]";
+        this._requestState();
+
+        GLib.timeout_add(GLib.PRIORITY_DEFAULT, 1000, () => {
+            this._requestState();
+
+            if (!this._devicePollCancelable.is_cancelled()) {
+                return GLib.SOURCE_CONTINUE;
+            } else {
+                return GLib.SOURCE_REMOVE;
+            }
+        });
+
+        if (this._bluez === null) {
+            this._bluez = Components.acquire('bluez');
+            this._bluezId = this._bluez.connect(
+                'changed',
+                this._receiveLocalState.bind(this)
+            );
+            this.local_devs_state = this._bluez.local_devices;
+        }
+    }
+
+    _dialogClosedCb() {
+        this._dialog = undefined;
+    }
+
+    _receiveLocalState() {
+        this.local_devs_state = this._bluez.local_devices;
+        this._update_combined_state();
+    }
+
+    /**
+     * Handle a remote state update.
+     *
+     * @param {Core.Packet} packet - A kdeconnect.bluetooth_handoff.device_list packet
+     */
+    _receiveRemoteState(packet) {
+        debug('Got device list: ' + JSON.stringify(packet.body));
+
+        // Update combined state
+        this.remote_devs_state = packet.body.devices;
+        this._update_combined_state();
+    }
+
+    /**
+     * Request the remote device's connectivity state
+     */
+    _requestState() {
+        debug("Requesting remote device list");
+        this.device.sendPacket({
+            type: 'kdeconnect.bluetooth_handoff.device_list.request',
+            body: {},
+        });
+    }
+
+    _update_combined_state() {
+        debug('--- local:  ' + JSON.stringify(this.local_devs_state));
+        debug('--- remote: ' + JSON.stringify(this.remote_devs_state));
+
+        let local_by_mac = {};
+        this.local_devs_state.forEach((dev) => {
+            local_by_mac[dev.addr] = dev;
+        });
+
+        let remote_by_mac = {};
+        this.remote_devs_state.forEach((dev) => {
+            remote_by_mac[dev.addr] = dev;
+        });
+
+        let combined = [];
+        Object.keys(local_by_mac).forEach((mac) => {
+            let local = local_by_mac[mac];
+            let remote = remote_by_mac[mac];
+            if (remote === undefined || (remote.connected === false && local.connected === false)) {
+                return;
+            }
+
+            let name = local.alias;
+            if (remote.name != local.alias) {
+                name = local.alias + ' (' + remote.name + ')';
+            }
+
+            combined.push({
+                'addr': mac,
+                'name': name,
+                'icon': local.icon,
+                'local_connected': local.connected,
+                'loading': false,
+            });
+        });
+
+        let combined_json = JSON.stringify(combined);
+        if (combined_json !== this.combined_devs_state_json) {
+            this.combined_devs_state = combined;
+            this.combined_devs_state_json = combined_json;
+            this.emit('combined-state-changed');
+        }
+    }
+
+    takeDevice(address) {
+        log('Sent dc req');
+        this.device.sendPacket({
+            type: 'kdeconnect.bluetooth_handoff.disconnect.request',
+            body: {
+                "addr": address,
+            },
+        });
+
+        GLib.timeout_add(GLib.PRIORITY_DEFAULT, 500, () => {
+            (async () => {
+                log('Starting local connect');
+                const launcher = new Gio.SubprocessLauncher({
+                    flags: Gio.SubprocessFlags.NONE,
+                });
+                const cancellable = new Gio.Cancellable();
+                GLib.timeout_add(GLib.PRIORITY_DEFAULT, 10000, () => {
+                    cancellable.cancel();
+                    return GLib.SOURCE_REMOVE;
+                });
+
+                for (let i = 0; i < 3; i++) {
+                    const proc = launcher.spawnv(['bluetoothctl', 'connect', address]);
+
+                    let success = await new Promise((resolve, reject) => {
+                        proc.wait_check_async(cancellable, (proc, res) => {
+                            try {
+                                proc.wait_check_finish(res);
+                                log('Connection successful!');
+                                resolve(true);
+                            } catch (e) {
+                                log('Connection unsuccessful: ' + e);
+                                resolve(false);
+                            }
+                        });
+                    });
+                    if (success) {
+                        break;
+                    }
+                }
+            })();
+
+            return GLib.SOURCE_REMOVE;
+        });
+    }
+
+    giveDevice(address) {
+        const launcher = new Gio.SubprocessLauncher({
+            flags: Gio.SubprocessFlags.NONE,
+        });
+        const cancellable = new Gio.Cancellable();
+        const proc = launcher.spawnv(['bluetoothctl', 'disconnect', address]);
+
+        GLib.timeout_add(GLib.PRIORITY_DEFAULT, 10000, () => {
+            cancellable.cancel();
+            return GLib.SOURCE_REMOVE;
+        });
+
+        proc.wait_check_async(cancellable, (proc, res) => {
+            try {
+                proc.wait_check_finish(res);
+                log('Disconnection successful!');
+            } catch (e) {
+                log('Disconnection unsuccessful: ' + e);
+                return;
+            }
+
+            this.device.sendPacket({
+                type: 'kdeconnect.bluetooth_handoff.connect.request',
+                body: {
+                    "addr": address,
+                },
+            });
+        });
+    }
+
+    destroy() {
+        if (this._dialog !== undefined)
+            this._dialog.destroy();
+
+        if (this._bluez !== null) {
+            this._bluez.disconnect(this._bluezId);
+            this._bluez = Components.release('bluez');
+        }
+
+        if (this._devicePollCancelable) {
+            this._devicePollCancelable.cancel();
+        }
+
+        super.destroy();
+    }
+});

--- a/src/service/ui/bluetoothHandoff.js
+++ b/src/service/ui/bluetoothHandoff.js
@@ -1,0 +1,134 @@
+'use strict';
+
+const Gdk = imports.gi.Gdk;
+const GLib = imports.gi.GLib;
+const GObject = imports.gi.GObject;
+const Gtk = imports.gi.Gtk;
+
+const DeviceRow = GObject.registerClass({
+    GTypeName: 'GSConnectBluetoothHandoffDeviceRow',
+    Template: 'resource:///org/gnome/Shell/Extensions/GSConnect/ui/bluetooth-handoff-device-row.ui',
+    Children: [
+        'device_icon', 'device_name', 'switch',
+    ],
+}, class DeviceRow extends Gtk.ListBoxRow {
+
+    _init(address, name, icon, connected, onToggle) {
+        super._init();
+
+        this._address = address;
+        this._name = name;
+        this._icon = icon;
+        this._connected = connected;
+        this._onToggle = onToggle;
+
+        this.handleEvents = false;
+        this.switch.state = connected;
+        this.handleEvents = true;
+
+        if (icon === 'audio-card') {
+            this.device_icon.icon_name = 'audio-headphones-symbolic';
+        } else {
+            this.device_icon.icon_name = 'bluetooth-active-symbolic';
+        }
+
+        this.device_name.label = name;
+    }
+
+    _onDeviceToggled(_widget, state) {
+        if (this.handleEvents) {
+            GLib.log_structured('GSConnect', GLib.LogLevelFlags.LEVEL_MESSAGE, {
+                'MESSAGE': 'Device Toggled: ' + this._address + ': ' + state,
+                'SYSLOG_IDENTIFIER': 'org.gnome.Shell.Extensions.GSConnect.BluetoothHandoff'
+            });
+            this._onToggle(this._address, state);
+        }
+    }
+});
+
+
+var BluetoothHandoffDialog = GObject.registerClass({
+    GTypeName: 'GSConnectBluetoothHandoffDialog',
+    Properties: {
+        'device': GObject.ParamSpec.object(
+            'device',
+            'Device',
+            'The device associated with this window',
+            GObject.ParamFlags.READWRITE,
+            GObject.Object
+        ),
+        'plugin': GObject.ParamSpec.object(
+            'plugin',
+            'Plugin',
+            'The bluetooth handoff plugin associated with this window',
+            GObject.ParamFlags.READWRITE,
+            GObject.Object
+        ),
+    },
+    Template: 'resource:///org/gnome/Shell/Extensions/GSConnect/ui/bluetooth-handoff-dialog.ui',
+    Children: [
+        'instruction-label', 'device_list',
+    ],
+}, class BluetoothHandoffDialog extends Gtk.Dialog {
+
+    _init(params, onDestroyCb) {
+        super._init(Object.assign({
+            use_header_bar: true,
+        }, params));
+
+        const headerbar = this.get_titlebar();
+        headerbar.title = _('Bluetooth Handoff');
+        headerbar.subtitle = _('Take Bluetooth devices from %s').format(this.device.name);
+
+        // Main Box
+        const content = this.get_content_area();
+        content.border_width = 0;
+
+        this.instruction_label.label = _('If your Bluetooth device doesn\'t show up, make sure both this PC and "%s" are near it').format(this.device.name);
+
+        // Clear the device list
+        const rows = this.device_list.get_children();
+
+        for (let i = 0, len = rows.length; i < len; i++) {
+            rows[i].destroy();
+            // HACK: temporary mitigator for mysterious GtkListBox leak
+            imports.system.gc();
+        }
+
+        this.plugin.connect('combined-state-changed', this._onStateChanged.bind(this));
+
+        // Cleanup on destroy
+        this._onDestroyCb = onDestroyCb;
+
+        this.show_all();
+    }
+
+    _onStateChanged() {
+        for (const widget of this.device_list.get_children()) {
+            widget.destroy();
+            // HACK: temporary mitigator for mysterious GtkListBox leak
+            imports.system.gc();
+        }
+
+        this.plugin.combined_devs_state.forEach((device, i) => {
+            const row = new DeviceRow(device.addr, device.name, device.icon, device.local_connected, this._onDeviceToggled.bind(this));
+            this.device_list.add(row);
+            if (i < this.plugin.combined_devs_state.length - 1) {
+                this.device_list.add(new Gtk.Separator());
+            }
+        });
+    }
+
+    _onDeviceToggled(address, state) {
+        if (state) {
+            this.plugin.takeDevice(address);
+        } else {
+            this.plugin.giveDevice(address);
+        }
+    }
+
+    vfunc_delete_event(event) {
+        this._onDestroyCb();
+        return false;
+    }
+});


### PR DESCRIPTION
This is an initial implementation of my new KDE connect feature:

![image](https://user-images.githubusercontent.com/6624767/164547144-59a89062-e7c5-4789-868e-f37ad77c52d6.png)

It lets you move bluetooth devices between the PC and the phone. Mostly intended for wireless headphones.

TODO list:
- Add spinner while operation in progress
- Refine UX
- Try many more devices
  - Bluetooth LE devices probably won't work at all, though they might not need to (need to check if they have multipath by default)
- Make sure everything is translatable
- Un-uglify code (I don't know enough about GObjects to use it correctly)
  - There are numerous object lifetime problems (Why is this a problem in a GC'd language? Whatever), which cause soft-crashes of the extension.
    Example: `Attempting to run a JS callback during garbage collection. This is most likely caused by destroying a Clutter actor or GTK widget with ::destroy signal connected, or using the destroy(), dispose(), or remove() vfuncs. Because it would crash the application, it has been blocked.`
- BSD support (Decouple from bluez + find hardware with working bluetooth and bsd at the same time)
- Tests