### PR TITLE
sms: Fix 'cache is not iterable'

### DIFF
--- a/src/service/plugins/sms.js
+++ b/src/service/plugins/sms.js
@@ -225,7 +225,7 @@ var Plugin = GObject.registerClass({
             }
 
             // If this message is marked read, mark the rest as read
-            if (message.read === MessageStatus.READ) {
+            if (message.read === MessageStatus.READ && cache.length > 0) {
                 for (const msg of cache)
                     msg.read = MessageStatus.READ;
             }


### PR DESCRIPTION
This PR fixes the following (harmless) error messages in the journal output, when there's no previous cache for a particular SMS thread:

```text
GSConnect[749788]: [/service/plugins/sms.js:_handleDigest:229]: SM-A536U1: cache is not iterable
                   _handleDigest@/home/ferd/.local/share/gnome-shell/extensions/gsconnect@andyholmes.github.io/service/plugins/sms.js:229:35
                   _handleMessages@/home/ferd/.local/share/gnome-shell/extensions/gsconnect@andyholmes.github.io/service/plugins/sms.js:331:22
                   handlePacket@/home/ferd/.local/share/gnome-shell/extensions/gsconnect@andyholmes.github.io/service/plugins/sms.js:199:22
                   handlePacket@/home/ferd/.local/share/gnome-shell/extensions/gsconnect@andyholmes.github.io/service/device.js:421:25
                   _readLoop@/home/ferd/.local/share/gnome-shell/extensions/gsconnect@andyholmes.github.io/service/device.js:345:22
                   async*setChannel@/home/ferd/.local/share/gnome-shell/extensions/gsconnect@andyholmes.github.io/service/device.js:323:18
                   _onChannel@/home/ferd/.local/share/gnome-shell/extensions/gsconnect@andyholmes.github.io/service/manager.js:225:20
                   channel@/home/ferd/.local/share/gnome-shell/extensions/gsconnect@andyholmes.github.io/service/core.js:448:19
                   _onIncomingChannel@/home/ferd/.local/share/gnome-shell/extensions/gsconnect@andyholmes.github.io/service/backends/lan.js:216:18
                   Async*@/home/ferd/.local/share/gnome-shell/extensions/gsconnect@andyholmes.github.io/service/daemon.js:727:17
```
