### PR TITLE
Use Adwaita 5G icon

### DIFF
--- a/src/service/plugins/connectivity_report.js
+++ b/src/service/plugins/connectivity_report.js
@@ -90,10 +90,8 @@ var Plugin = GObject.registerClass({
             return 'network-cellular-gprs-symbolic';
         else if (this.network_type === 'HSPA')
             return 'network-cellular-hspa-symbolic';
-        // FIXME: No icon for this!
-        // https://gitlab.gnome.org/GNOME/adwaita-icon-theme/-/issues/114
         else if (this.network_type === '5G')
-            return 'network-cellular-symbolic';
+            return 'network-cellular-5g-symbolic';
 
         return 'network-cellular-symbolic';
     }


### PR DESCRIPTION
While [5G detection](https://developer.android.com/about/versions/11/features/5g#detection) is a deceptively tricky thing that we can't fully provide without knowing the "override network type", something that will require additional support from the Android app (see #1348, KDE [bug 454120](https://bugs.kde.org/show_bug.cgi?id=454120)), we _can_ at least use the 5G icon Adwaita now provides for the devices that **are** currently detected as having 5G connectivity.
