### PR TITLE
Add v49 & v50 to metainfo

### DIFF
--- a/data/metainfo/org.gnome.Shell.Extensions.GSConnect.metainfo.xml.in
+++ b/data/metainfo/org.gnome.Shell.Extensions.GSConnect.metainfo.xml.in
@@ -49,6 +49,12 @@
   </description>
 
   <releases>
+    <release version="50" date="2022-03-19">
+      <url>https://github.com/GSConnect/gnome-shell-extension-gsconnect/releases/tag/v50</url>
+    </release>
+    <release version="49" date="2022-03-19">
+      <url>https://github.com/GSConnect/gnome-shell-extension-gsconnect/releases/tag/v49</url>
+    </release>
     <release version="48" date="2021-10-03">
       <url>https://github.com/GSConnect/gnome-shell-extension-gsconnect/releases/tag/v48</url>
     </release>


### PR DESCRIPTION
Just some housekeeping: Add the two most recent releases to the metainfo file.