### PR TITLE
Update packaging to current version

### DIFF
--- a/data/metainfo/org.gnome.Shell.Extensions.GSConnect.metainfo.xml.in
+++ b/data/metainfo/org.gnome.Shell.Extensions.GSConnect.metainfo.xml.in
@@ -49,6 +49,12 @@
   </description>
 
   <releases>
+    <release version="53" date="2022-03-20">
+      <url>https://github.com/GSConnect/gnome-shell-extension-gsconnect/releases/tag/v53</url>
+    </release>
+    <release version="51" date="2022-03-20">
+      <url>https://github.com/GSConnect/gnome-shell-extension-gsconnect/releases/tag/v51</url>
+    </release>
     <release version="50" date="2022-03-19">
       <url>https://github.com/GSConnect/gnome-shell-extension-gsconnect/releases/tag/v50</url>
     </release>

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('gsconnect',
   'c',
-  version: '50',
+  version: '53',
   meson_version: '>= 0.46.0'
 )
 


### PR DESCRIPTION
Well, #1360 was nice and all, but we're actually up to version _53_. Which wasn't up to date in `meson.build`, either.