### PR TITLE
meson: remove deprecated functions

### DIFF
--- a/.github/workflows/gnome-3-36.yml
+++ b/.github/workflows/gnome-3-36.yml
@@ -18,7 +18,6 @@ jobs:
           meson --prefix=/usr \
                 --libdir=lib/ \
                 -Dgnome_shell_libdir=/usr/lib64/ \
-                -Dpost_install=true \
                 _build
 
       - name: Uninstalled Tests

--- a/.github/workflows/gnome-3-38.yml
+++ b/.github/workflows/gnome-3-38.yml
@@ -18,7 +18,6 @@ jobs:
           meson --prefix=/usr \
                 --libdir=lib/ \
                 -Dgnome_shell_libdir=/usr/lib64/ \
-                -Dpost_install=true \
                 _build
 
       - name: Uninstalled Tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     container:
-      image: gsconnect/gsconnect-ci:latest
+      image: ghcr.io/gsconnect/gsconnect-ci:main
     steps:
       - uses: actions/checkout@v2
       - name: Prepare
@@ -21,7 +21,6 @@ jobs:
           meson --prefix=/usr \
                 --libdir=lib/ \
                 -Dgnome_shell_libdir=/usr/lib64/ \
-                -Dpost_install=true \
                 _build
 
       - name: Uninstalled Tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,7 +107,6 @@ $ meson --prefix=/usr \
         --libdir=lib/ \
         -Dgnome_shell_libdir=/usr/lib64/ \
         -Dfirewalld=true \
-        -Dpost_install=true \
         _build
 $ ninja -C _build install
 ```

--- a/build-aux/meson/post-install.sh
+++ b/build-aux/meson/post-install.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-GSCHEMA_DIR="${DESTDIR}/${GSCHEMADIR}"
-
-glib-compile-schemas "${GSCHEMA_DIR}"

--- a/data/meson.build
+++ b/data/meson.build
@@ -63,7 +63,11 @@ dbus = dependency('dbus-1', required: false)
 if get_option('session_bus_services_dir') != ''
   dbus_dir = get_option('session_bus_services_dir')
 elif dbus.found()
-  dbus_dir = dbus.get_pkgconfig_variable('session_bus_services_dir')
+  dbus_dir = dbus.get_variable(
+    pkgconfig: 'session_bus_services_dir',
+    internal: 'session_bus_services_dir',
+    default_value: join_paths(datadir, 'dbus-1', 'services'),
+  )
 else
   dbus_dir = join_paths(datadir, 'dbus-1', 'services')
 endif

--- a/installed-tests/meson.build
+++ b/installed-tests/meson.build
@@ -27,8 +27,8 @@ installed_tests_prepared = custom_target(
   build_by_default: true,
            command: [
              env_util,
-             'MESON_BUILD_ROOT=' + meson.build_root(),
-             'MESON_SOURCE_ROOT=' + meson.source_root(),
+             'MESON_BUILD_ROOT=' + meson.project_build_root(),
+             'MESON_SOURCE_ROOT=' + meson.project_source_root(),
              'G_TEST_BUILDDIR=' + installed_tests_builddir,
              'G_TEST_SRCDIR=' + installed_tests_srcdir,
              join_paths(installed_tests_srcdir, 'prepare-tests.sh')

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('gsconnect',
   'c',
   version: '53',
-  meson_version: '>= 0.46.0'
+  meson_version: '>= 0.59.0',
 )
 
 gnome = import('gnome')
@@ -19,13 +19,7 @@ libexecdir = join_paths(prefix, get_option('libexecdir'))
 localedir = join_paths(prefix, get_option('localedir'))
 sysconfdir = get_option('sysconfdir')
 
-
-# GSettings schema dir
-if get_option('gsettings_schemadir') != ''
-  gschemadir = get_option('gsettings_schemadir')
-else
-  gschemadir = join_paths(datadir, 'glib-2.0', 'schemas')
-endif
+gschemadir = join_paths(datadir, 'glib-2.0', 'schemas')
 
 
 # GNOME Shell LIBDIR
@@ -66,7 +60,7 @@ run_target(
     'DATADIR=' + datadir,
     'LOCALEDIR=' + localedir,
     'GSCHEMADIR=' + gschemadir,
-    join_paths(meson.source_root(), 'build-aux', 'ego', 'mkzip.sh')
+    join_paths(meson.project_source_root(), 'build-aux', 'ego', 'mkzip.sh')
   ]
 )
 
@@ -79,19 +73,17 @@ run_target(
     'LOCALEDIR=' + localedir,
     'GSCHEMADIR=' + gschemadir,
     'INSTALL=true',
-    join_paths(meson.source_root(), 'build-aux', 'ego', 'mkzip.sh')
+    join_paths(meson.project_source_root(), 'build-aux', 'ego', 'mkzip.sh')
   ]
 )
 
 
 # Post-Install script for distributions without the hooks
-if get_option('post_install')
-    meson.add_install_script(
-      env_util.path(),
-      'GSCHEMADIR=' + gschemadir,
-      join_paths(meson.source_root(), 'build-aux', 'meson', 'post-install.sh')
-    )
-endif
+gnome.post_install(
+  glib_compile_schemas: true,
+  gtk_update_icon_cache: true,
+  update_desktop_database: true,
+)
 
 
 # Extension Source
@@ -105,15 +97,15 @@ eslint = find_program('eslint', required: false)
 
 if eslint.found()
   test('ESLint (Source)', eslint,
-    args: join_paths(meson.source_root(), 'src'),
+    args: join_paths(meson.project_source_root(), 'src'),
     suite: 'lint',
   )
   test('ESLint (Installed Tests)', eslint,
-    args: join_paths(meson.source_root(), 'installed-tests'),
+    args: join_paths(meson.project_source_root(), 'installed-tests'),
     suite: 'lint',
   )
   test('ESLint (WebExtension)', eslint,
-    args: join_paths(meson.source_root(), 'webextension'),
+    args: join_paths(meson.project_source_root(), 'webextension'),
     suite: 'lint',
   )
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,27 +1,11 @@
 # See https://github.com/GSConnect/gnome-shell-extension-gsconnect/wiki/Packaging
 
-# Run meson/post-install.sh (glib-compile-schemas)
-option(
-  'post_install',
-  type: 'boolean',
-  value: false,
-  description: 'Run meson/post-install.sh (eg. glib-compile-schemas)'
-)
-
 # GNOME Shell LIBDIR
 option(
   'gnome_shell_libdir',
   type: 'string',
   value: '',
   description: 'LIBDIR for GNOME Shell (eg. $LIBDIR/gnome-shell/Gvc-1.0.typelib)'
-)
-
-# GSettings schema directory
-option(
-  'gsettings_schemadir',
-  type: 'string',
-  value: '',
-  description: 'GSettings Schema directory'
 )
 
 # DBus service file

--- a/src/service/core.js
+++ b/src/service/core.js
@@ -83,14 +83,14 @@ var Packet = class Packet {
     /**
      * Update the packet from a dictionary or string of JSON
      *
-     * @param {Object|string} source - Source data
+     * @param {Object|string} data - Source data
      */
-    update(source) {
+    update(data) {
         try {
             if (typeof data === 'string')
-                Object.assign(this, JSON.parse(source));
+                Object.assign(this, JSON.parse(data));
             else
-                Object.assign(this, source);
+                Object.assign(this, data);
         } catch (e) {
             throw Error(`Malformed data: ${e.message}`);
         }


### PR DESCRIPTION
Remove usage of `meson.source_root()` and `meson.build_root()`, then
bump the required version to `>= 0.56.0`.