### PR TITLE
.editorconfig: add trim_trailing_whitespace

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,9 +5,10 @@ root = true
 # All files: UTF-8 with Unix-style newlines,
 # and a newline at the end of the file
 [*]
-insert_final_newline = true
-end_of_line = lf
 charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
 
 # JavaScript, Python, CSS: 4-space indents
 [*.{js,py,css}]


### PR DESCRIPTION
Just a quick tweak to the editorconfig, to enable `trim_trailing_whitespace`. (Per line, from the ends.)

Shuffled the settings so they're ordered progressively by scope: first character, then line, then file.