### PR TITLE
Fixes issue #1406

### DIFF
--- a/src/service/plugins/mousepad.js
+++ b/src/service/plugins/mousepad.js
@@ -191,7 +191,14 @@ var Plugin = GObject.registerClass({
 
                 // Special key (eg. non-printable ASCII)
                 } else if (input.specialKey && KeyMap.has(input.specialKey)) {
-                    keysym = KeyMap.get(input.specialKey);
+                    // Convert PageUp and PageDown to Left and Right respectively
+                    // This is done to fix Slideshow Remote
+                    if (input.specialKey === 8)
+                        keysym = KeyMap.get(4)
+                    else if (input.specialKey === 9)
+                        keysym = KeyMap.get(6)
+                    else
+                        keysym = KeyMap.get(input.specialKey);
                     this._input.pressKeys(keysym, modifiers);
                     this._sendEcho(input);
                 }

--- a/src/service/plugins/mousepad.js
+++ b/src/service/plugins/mousepad.js
@@ -194,9 +194,9 @@ var Plugin = GObject.registerClass({
                     // Convert PageUp and PageDown to Left and Right respectively
                     // This is done to fix Slideshow Remote
                     if (input.specialKey === 8)
-                        keysym = KeyMap.get(4)
+                        keysym = KeyMap.get(4);
                     else if (input.specialKey === 9)
-                        keysym = KeyMap.get(6)
+                        keysym = KeyMap.get(6);
                     else
                         keysym = KeyMap.get(input.specialKey);
                     this._input.pressKeys(keysym, modifiers);

--- a/src/service/plugins/mousepad.js
+++ b/src/service/plugins/mousepad.js
@@ -191,14 +191,7 @@ var Plugin = GObject.registerClass({
 
                 // Special key (eg. non-printable ASCII)
                 } else if (input.specialKey && KeyMap.has(input.specialKey)) {
-                    // Convert PageUp and PageDown to Left and Right respectively
-                    // This is done to fix Slideshow Remote
-                    if (input.specialKey === 8)
-                        keysym = KeyMap.get(4);
-                    else if (input.specialKey === 9)
-                        keysym = KeyMap.get(6);
-                    else
-                        keysym = KeyMap.get(input.specialKey);
+                    keysym = KeyMap.get(parseInt(input.specialKey));
                     this._input.pressKeys(keysym, modifiers);
                     this._sendEcho(input);
                 }


### PR DESCRIPTION
### Brief Description
Fixes issue #1406. The Slideshow Remote feature has a bug where Previous Slide and Next Slide does not work. The pull request fixes this issue.

### Explanation
The feature did not work because the buttons would send a `kdeconnect.mousepad.request` with the `specialKey = 8` (for Previous Slide) and a `specialKey = 9` (for Next Slide). However, these `specialKey` values are key-mapped to `Page Up` and `Page Down` input which has no effect on a presentation slideshow.
The fix converts the `specialKey = 8` and `9` values to `4` and `6` respectively, which corresponds to Left and Right arrow key inputs.