### PR TITLE
nautilus: Update for compatibility with Nautilus 43

### DIFF
--- a/nautilus-extension/nautilus-gsconnect.py
+++ b/nautilus-extension/nautilus-gsconnect.py
@@ -29,7 +29,6 @@ if "nemo" in sys.argv[0].lower():
     from gi.repository import Nemo as FileManager
 else:
     # Otherwise, just assume it's nautilus-python
-    gi.require_version('Nautilus', '3.0')
     from gi.repository import Nautilus as FileManager
 
 

--- a/nautilus-extension/nautilus-gsconnect.py
+++ b/nautilus-extension/nautilus-gsconnect.py
@@ -140,7 +140,10 @@ class GSConnectShareExtension(GObject.Object, FileManager.MenuProvider):
             variant = GLib.Variant('(sb)', (file.get_uri(), False))
             action_group.activate_action('shareFile', variant)
 
-    def get_file_items(self, window, files):
+    def get_file_items(self, *args):
+        # `args` will be `[files: List[Nautilus.FileInfo]]` in Nautilus 4.0 API,
+        # and `[window: Gtk.Widget, files: List[Nautilus.FileInfo]]` in Nautilus 3.0 API.
+        files = args[-1]
         """Return a list of select files to be sent"""
 
         # Only accept regular files


### PR DESCRIPTION
and nautilus-python 4.0.alpha

Use the suggestion from
https://gitlab.gnome.org/GNOME/nautilus-python/-/blob/master/docs/reference/nautilus-python-migrating-to-4.xml

Closes: https://github.com/GSConnect/gnome-shell-extension-gsconnect/issues/1419