### PR TITLE
Remote Keyboard: Fixed referencing text area from plugin.

### DIFF
--- a/src/service/plugins/mousepad.js
+++ b/src/service/plugins/mousepad.js
@@ -241,10 +241,10 @@ var Plugin = GObject.registerClass({
 
         if (input.key) {
             this._dialog._isAck = true;
-            this._dialog.text.buffer.text += input.key;
+            this._dialog.entry.buffer.text += input.key;
             this._dialog._isAck = false;
         } else if (KeyMap.get(input.specialKey) === Gdk.KEY_BackSpace) {
-            this._dialog.text.emit('backspace');
+            this._dialog.entry.emit('backspace');
         }
     }
 


### PR DESCRIPTION
Previously, plugin side (`plugins/mousepad.js`) referenced text area as `text`, while it is `entry` in ui side (`ui/mousepad.js`).

Changed its name in plugin side, to `entry`.