### PR TITLE
Reimplementation of GS preferences for Gnome 42-43.

### DIFF
--- a/src/prefs.js
+++ b/src/prefs.js
@@ -13,11 +13,11 @@ function init() {
 function fillPreferencesWindow(window) {
     const widget = new Adw.PreferencesPage();
     window.add(widget);
-    
+
     GLib.idle_add(GLib.PRIORITY_DEFAULT_IDLE, () => {
         window.close();
     });
-    
+
     Gio.Subprocess.new([`${Extension.path}/gsconnect-preferences`], 0);
 }
 

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -1,8 +1,6 @@
 'use strict';
 
-const Gio = imports.gi.Gio;
-const GLib = imports.gi.GLib;
-const Gtk = imports.gi.Gtk;
+const {Gio, GLib, Adw} = imports.gi;
 
 // Bootstrap
 const Extension = imports.misc.extensionUtils.getCurrentExtension();
@@ -12,17 +10,14 @@ function init() {
     Utils.installService();
 }
 
-function buildPrefsWidget() {
-    // Destroy the window once the mainloop starts
-    const widget = new Gtk.Box();
-
+function fillPreferencesWindow(window) {
+    const widget = new Adw.PreferencesPage();
+    window.add(widget);
+    
     GLib.idle_add(GLib.PRIORITY_DEFAULT_IDLE, () => {
-        widget.get_root().destroy();
-        return false;
+        window.close();
     });
-
+    
     Gio.Subprocess.new([`${Extension.path}/gsconnect-preferences`], 0);
-
-    return widget;
 }
 


### PR DESCRIPTION
From Gnome Shell 42 preferences dialog is using Adw.PreferencesWindow instead of Gtk.Window, and introduce a new function "fillPreferencesWindow()" to fill the preferences window.
This resolve #1213.