### PR TITLE
Show transfered file in folder as default action of notification (replaces #1039)

### DIFF
--- a/src/service/plugins/share.js
+++ b/src/service/plugins/share.js
@@ -164,7 +164,7 @@ var Plugin = GObject.registerClass({
             });
 
             // We'll show a notification (success or failure)
-            let title, body, iconName;
+            let title, body, action, iconName;
             let buttons = [];
 
             try {
@@ -176,11 +176,15 @@ var Plugin = GObject.registerClass({
                     packet.body.filename,
                     this.device.name
                 );
+                action = {
+                    name: 'showPathInFolder',
+                    parameter: new GLib.Variant('s', file.get_uri()),
+                };
                 buttons = [
                     {
-                        label: _('Open Folder'),
-                        action: 'openPath',
-                        parameter: new GLib.Variant('s', file.get_parent().get_uri()),
+                        label: _('Show File Location'),
+                        action: 'showPathInFolder',
+                        parameter: new GLib.Variant('s', file.get_uri()),
                     },
                     {
                         label: _('Open File'),
@@ -214,6 +218,7 @@ var Plugin = GObject.registerClass({
                 id: transfer.uuid,
                 title: title,
                 body: body,
+                action: action,
                 buttons: buttons,
                 icon: new Gio.ThemedIcon({name: iconName}),
             });


### PR DESCRIPTION
This PR finishes up the changes for PR #1039, with most of the work done by @HaMF over there. I just tacked on a commit with some review suggestions. Differences from the original PR:

1. The function is renamed `showPathInFolder`, as suggested
2. In addition to being the default click action for the notification, it's also made the "Open Folder" button action. (Now renamed to "Show File Location". I decided that "Open File Location" and "Open File" right next to each other was too confusing, so I didn't go with that.)
3. The D-Bus call made to launch the file manager now passes a result callback that finishes the request, or logs an error if encountered.

Closes #1009 
<s>Closes #1039  (←- I don't think this will work, but...)</s> It does not work, probably-sensibly.