### PR TITLE
Calculate a verification key that matches KDE/Android

### DIFF
--- a/src/service/__init__.js
+++ b/src/service/__init__.js
@@ -397,5 +397,33 @@ Object.defineProperties(Gio.TlsCertificate.prototype, {
         },
         enumerable: true,
     },
-});
 
+    /**
+     * Get just the pubkey as a DER ByteArray of a certificate.
+     *
+     * @return {GLib.Bytes} The pubkey as DER of the certificate.
+     */
+    'pubkey_der': {
+        value: function () {
+            if (!this.__pubkey_der) {
+                let proc = new Gio.Subprocess({
+                    argv: [Config.OPENSSL_PATH, 'x509', '-noout', '-pubkey', '-inform', 'pem'],
+                    flags: Gio.SubprocessFlags.STDIN_PIPE | Gio.SubprocessFlags.STDOUT_PIPE,
+                });
+                proc.init(null);
+
+                const pubkey = proc.communicate_utf8(this.certificate_pem, null)[1];
+                proc = new Gio.Subprocess({
+                    argv: [Config.OPENSSL_PATH, 'pkey', '-pubin', '-inform', 'pem', '-outform', 'der'],
+                    flags: Gio.SubprocessFlags.STDIN_PIPE | Gio.SubprocessFlags.STDOUT_PIPE,
+                });
+                proc.init(null);
+                this.__pubkey_der = proc.communicate(ByteArray.fromString(pubkey), null)[1];
+            }
+
+            return this.__pubkey_der;
+        },
+        enumerable: false,
+    },
+
+});

--- a/src/service/__init__.js
+++ b/src/service/__init__.js
@@ -354,30 +354,6 @@ Gio.TlsCertificate.new_for_paths = function (certPath, keyPath, commonName = nul
 
 Object.defineProperties(Gio.TlsCertificate.prototype, {
     /**
-     * Compute a SHA256 fingerprint of the certificate.
-     * See: https://gitlab.gnome.org/GNOME/glib/issues/1290
-     *
-     * @return {string} A SHA256 fingerprint of the certificate.
-     */
-    'sha256': {
-        value: function () {
-            if (!this.__fingerprint) {
-                const proc = new Gio.Subprocess({
-                    argv: [Config.OPENSSL_PATH, 'x509', '-noout', '-fingerprint', '-sha256', '-inform', 'pem'],
-                    flags: Gio.SubprocessFlags.STDIN_PIPE | Gio.SubprocessFlags.STDOUT_PIPE,
-                });
-                proc.init(null);
-
-                const stdout = proc.communicate_utf8(this.certificate_pem, null)[1];
-                this.__fingerprint = /[a-zA-Z0-9:]{95}/.exec(stdout)[0];
-            }
-
-            return this.__fingerprint;
-        },
-        enumerable: false,
-    },
-
-    /**
      * The common name of the certificate.
      */
     'common_name': {

--- a/src/service/device.js
+++ b/src/service/device.js
@@ -160,8 +160,6 @@ var Device = GObject.registerClass({
 
     // FIXME: backend should do this stuff
     get encryption_info() {
-        let remoteFingerprint = _('Not available');
-        let localFingerprint = _('Not available');
         let localCert = null;
         let remoteCert = null;
 
@@ -173,7 +171,6 @@ var Device = GObject.registerClass({
         // If the device is connected use the certificate from the connection
         } else if (this.connected) {
             remoteCert = this.channel.peer_certificate;
-            remoteFingerprint = remoteCert.sha256();
 
         // Otherwise pull it out of the settings
         } else if (this.paired) {
@@ -181,7 +178,6 @@ var Device = GObject.registerClass({
                 this.settings.get_string('certificate-pem'),
                 -1
             );
-            remoteFingerprint = remoteCert.sha256();
         }
 
         // FIXME: another ugly reach-around
@@ -190,10 +186,9 @@ var Device = GObject.registerClass({
         if (this.service !== null)
             lanBackend = this.service.manager.backends.get('lan');
 
-        if (lanBackend && lanBackend.certificate) {
+        if (lanBackend && lanBackend.certificate)
             localCert = lanBackend.certificate;
-            localFingerprint = localCert.sha256();
-        }
+
 
         let verificationKey = '';
         if (localCert && remoteCert) {
@@ -201,7 +196,7 @@ var Device = GObject.registerClass({
             let b = remoteCert.pubkey_der();
             if (a.compare(b) < 0)
                 [a, b] = [b, a]; // swap
-            let checksum = new GLib.Checksum(GLib.ChecksumType.SHA256);
+            const checksum = new GLib.Checksum(GLib.ChecksumType.SHA256);
             checksum.update(ByteArray.fromGBytes(a));
             checksum.update(ByteArray.fromGBytes(b));
             verificationKey = checksum.get_string();


### PR DESCRIPTION
This is based on earlier work by @strugee in https://github.com/GSConnect/gnome-shell-extension-gsconnect/pull/1148.

When the other party initiates the request the verification key is shown as a notification as before, but it doesn't seem to be shown anywhere. The previous pull request could be maybe rebased on top of this, as I think it had some UI for that?

I think the GLib checksum should "just work" with Javascript, and when I took away the call to `.free` both errors "code should not be reached" and the segfault that (according to gdb) happened inside g_checksum_copy went away.

There's a bug on the KDE Connect Android side that has been fixed in master (https://invent.kde.org/network/kdeconnect-android/-/commit/8f49ff57ab43961bea65cddd35b250f7f5301567), but not yet released to F-Droid which leaves out the last two characters from the verification key on the Android side. I think we should still show the full thing as it has been fixed already even if not released yet.

I developed this against Gnome 42, so for testing can definitely be cherry picked against that.