### PR TITLE
A couple of eslint adjustments: limit nested callbacks (more), and group accessors with sensible ordering

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -57,6 +57,10 @@
                 "allowArrowFunctions": true
             }
         ],
+        "grouped-accessor-pairs": [
+            "error",
+            "getBeforeSet"
+        ],
         "indent": [
             "error",
             4,
@@ -87,7 +91,12 @@
             "unix"
         ],
         "lines-between-class-members": "error",
-        "max-nested-callbacks": "error",
+        "max-nested-callbacks": [
+            "error",
+            {
+                "max": 5
+            }
+        ],
         "max-statements-per-line": "error",
         "new-parens": "error",
         "no-array-constructor": "error",


### PR DESCRIPTION
Two relatively minor tweaks to the `.eslintrc.json` file that don't affect the _current_ passing status of the code, but could catch some issues should they creep in down the road.

### `max-nested-callbacks`
We're using `max-nested-callbacks`, but with the default level which is **`10`**. That seems excessive to me. Since some of the suites in the `installed-tests` currently make it up to `4`, I dropped it to `5` so there's a little buffer, but it doesn't give people room to go crazy.

### `grouped-accessor-pairs`
The check [`grouped-accessor-pairs`](https://eslint.org/docs/latest/rules/grouped-accessor-pairs) seems sensible:
> A getter and setter for the same property don’t necessarily have to be defined adjacent to each other.
> [...]
> While it is allowed to define the pair for a getter or a setter anywhere in an object or class definition, it’s considered a best practice to group accessor functions for the same property.
> 
> In other words, if a property has a getter and a setter, the setter should be defined right after the getter, or vice versa.

So, that's enabled as an `"error"` check like all the others. The string option `"getBeforeSet"` is further included, to additionally require that a property's getter come before its setter. Again, just common sense, and all of the existing code passes.