### PR TITLE
Add Python linting for Nautilus extension

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+extend-ignore = E402

--- a/meson.build
+++ b/meson.build
@@ -118,7 +118,7 @@ if black.found()
       '--diff',
       join_paths(meson.project_source_root(), 'nautilus-extension')
     ],
-    suite: 'lint-python',
+    suite: 'lint',
   )
 endif
 
@@ -126,7 +126,7 @@ flake8 = find_program('flake8', required: false)
 if flake8.found()
   test('Python Flake8 (Nautilus Extension)', flake8,
     args: join_paths(meson.project_source_root(), 'nautilus-extension'),
-    suite: 'lint-python',
+    suite: 'lint',
   )
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -110,6 +110,26 @@ if eslint.found()
   )
 endif
 
+black = find_program('black', required: false)
+if black.found()
+  test('Python Black (Nautilus Extension)', black,
+    args: [
+      '--check',
+      '--diff',
+      join_paths(meson.project_source_root(), 'nautilus-extension')
+    ],
+    suite: 'lint-python',
+  )
+endif
+
+flake8 = find_program('flake8', required: false)
+if flake8.found()
+  test('Python Flake8 (Nautilus Extension)', flake8,
+    args: join_paths(meson.project_source_root(), 'nautilus-extension'),
+    suite: 'lint-python',
+  )
+endif
+
 
 subdir('data')
 subdir('installed-tests')

--- a/nautilus-extension/nautilus-gsconnect.py
+++ b/nautilus-extension/nautilus-gsconnect.py
@@ -12,9 +12,10 @@ import os.path
 import sys
 
 import gi
-gi.require_version('Gio', '2.0')
-gi.require_version('GLib', '2.0')
-gi.require_version('GObject', '2.0')
+
+gi.require_version("Gio", "2.0")
+gi.require_version("GLib", "2.0")
+gi.require_version("GObject", "2.0")
 from gi.repository import Gio, GLib, GObject
 
 
@@ -25,34 +26,37 @@ from gi.repository import Gio, GLib, GObject
 # See https://github.com/linuxmint/nemo-extensions/issues/330
 if "nemo" in sys.argv[0].lower():
     # Host runtime is nemo-python
-    gi.require_version('Nemo', '3.0')
+    gi.require_version("Nemo", "3.0")
     from gi.repository import Nemo as FileManager
 else:
     # Otherwise, just assume it's nautilus-python
     from gi.repository import Nautilus as FileManager
 
 
-SERVICE_NAME = 'org.gnome.Shell.Extensions.GSConnect'
-SERVICE_PATH = '/org/gnome/Shell/Extensions/GSConnect'
+SERVICE_NAME = "org.gnome.Shell.Extensions.GSConnect"
+SERVICE_PATH = "/org/gnome/Shell/Extensions/GSConnect"
 
 # Init gettext translations
-LOCALE_DIR = os.path.join(GLib.get_user_data_dir(),
-                          'gnome-shell', 'extensions',
-                          'gsconnect@andyholmes.github.io', 'locale')
+LOCALE_DIR = os.path.join(
+    GLib.get_user_data_dir(),
+    "gnome-shell",
+    "extensions",
+    "gsconnect@andyholmes.github.io",
+    "locale",
+)
 
 if not os.path.exists(LOCALE_DIR):
     LOCALE_DIR = None
 
 try:
-    i18n = gettext.translation(SERVICE_NAME,
-                               localedir=LOCALE_DIR)
+    i18n = gettext.translation(SERVICE_NAME, localedir=LOCALE_DIR)
     _ = i18n.gettext
 
 except (IOError, OSError) as e:
-    print('GSConnect: {0}'.format(e.strerror))
-    i18n = gettext.translation(SERVICE_NAME,
-                               localedir=LOCALE_DIR,
-                               fallback=True)
+    print("GSConnect: {0}".format(e.strerror))
+    i18n = gettext.translation(
+        SERVICE_NAME, localedir=LOCALE_DIR, fallback=True
+    )
     _ = i18n.gettext
 
 
@@ -60,26 +64,27 @@ class GSConnectShareExtension(GObject.Object, FileManager.MenuProvider):
     """A context menu for sending files via GSConnect."""
 
     def __init__(self):
-        """Initialize the DBus ObjectManager"""
-
+        """Initialize the DBus ObjectManager."""
         GObject.Object.__init__(self)
 
         self.devices = {}
 
-        Gio.DBusProxy.new_for_bus(Gio.BusType.SESSION,
-                                  Gio.DBusProxyFlags.DO_NOT_AUTO_START,
-                                  None,
-                                  SERVICE_NAME,
-                                  SERVICE_PATH,
-                                  'org.freedesktop.DBus.ObjectManager',
-                                  None,
-                                  self._init_async,
-                                  None)
+        Gio.DBusProxy.new_for_bus(
+            Gio.BusType.SESSION,
+            Gio.DBusProxyFlags.DO_NOT_AUTO_START,
+            None,
+            SERVICE_NAME,
+            SERVICE_PATH,
+            "org.freedesktop.DBus.ObjectManager",
+            None,
+            self._init_async,
+            None,
+        )
 
     def _init_async(self, proxy, res, user_data):
         proxy = proxy.new_for_bus_finish(res)
-        proxy.connect('notify::g-name-owner', self._on_name_owner_changed)
-        proxy.connect('g-signal', self._on_g_signal)
+        proxy.connect("notify::g-name-owner", self._on_name_owner_changed)
+        proxy.connect("g-signal", self._on_g_signal)
 
         self._on_name_owner_changed(proxy, None)
 
@@ -90,16 +95,17 @@ class GSConnectShareExtension(GObject.Object, FileManager.MenuProvider):
 
         objects = parameters.unpack()
 
-        if signal_name == 'InterfacesAdded':
+        if signal_name == "InterfacesAdded":
             for object_path, props in objects.items():
-                props = props['org.gnome.Shell.Extensions.GSConnect.Device']
+                props = props["org.gnome.Shell.Extensions.GSConnect.Device"]
 
-                self.devices[object_path] = (props['Name'],
-                                             Gio.DBusActionGroup.get(
-                                                 proxy.get_connection(),
-                                                 SERVICE_NAME,
-                                                 object_path))
-        elif signal_name == 'InterfacesRemoved':
+                self.devices[object_path] = (
+                    props["Name"],
+                    Gio.DBusActionGroup.get(
+                        proxy.get_connection(), SERVICE_NAME, object_path
+                    ),
+                )
+        elif signal_name == "InterfacesRemoved":
             for object_path in objects:
                 try:
                     del self.devices[object_path]
@@ -111,51 +117,56 @@ class GSConnectShareExtension(GObject.Object, FileManager.MenuProvider):
         if proxy.props.g_name_owner is None:
             self.devices = {}
         else:
-            proxy.call('GetManagedObjects',
-                       None,
-                       Gio.DBusCallFlags.NO_AUTO_START,
-                       -1,
-                       None,
-                       self._get_managed_objects,
-                       None)
+            proxy.call(
+                "GetManagedObjects",
+                None,
+                Gio.DBusCallFlags.NO_AUTO_START,
+                -1,
+                None,
+                self._get_managed_objects,
+                None,
+            )
 
     def _get_managed_objects(self, proxy, res, user_data):
         objects = proxy.call_finish(res)[0]
 
         for object_path, props in objects.items():
-            props = props['org.gnome.Shell.Extensions.GSConnect.Device']
+            props = props["org.gnome.Shell.Extensions.GSConnect.Device"]
             if not props:
                 continue
 
-            self.devices[object_path] = (props['Name'],
-                                         Gio.DBusActionGroup.get(
-                                             proxy.get_connection(),
-                                             SERVICE_NAME,
-                                             object_path))
+            self.devices[object_path] = (
+                props["Name"],
+                Gio.DBusActionGroup.get(
+                    proxy.get_connection(), SERVICE_NAME, object_path
+                ),
+            )
 
     def send_files(self, menu, files, action_group):
-        """Send *files* to *device_id*"""
-
+        """Send *files* to *device_id*."""
         for file in files:
-            variant = GLib.Variant('(sb)', (file.get_uri(), False))
-            action_group.activate_action('shareFile', variant)
+            variant = GLib.Variant("(sb)", (file.get_uri(), False))
+            action_group.activate_action("shareFile", variant)
 
     def get_file_items(self, *args):
-        # `args` will be `[files: List[Nautilus.FileInfo]]` in Nautilus 4.0 API,
-        # and `[window: Gtk.Widget, files: List[Nautilus.FileInfo]]` in Nautilus 3.0 API.
+        """Return a list of select files to be sent."""
+        # 'args' will depend on the Nautilus API version.
+        # * Nautilus 4.0:
+        #     `[files: List[Nautilus.FileInfo]]`
+        # * Nautilus 3.0:
+        #     `[window: Gtk.Widget, files: List[Nautilus.FileInfo]]`
         files = args[-1]
-        """Return a list of select files to be sent"""
 
         # Only accept regular files
         for uri in files:
-            if uri.get_uri_scheme() != 'file' or uri.is_directory():
+            if uri.get_uri_scheme() != "file" or uri.is_directory():
                 return ()
 
         # Enumerate capable devices
         devices = []
 
         for name, action_group in self.devices.values():
-            if action_group.get_action_enabled('shareFile'):
+            if action_group.get_action_enabled("shareFile"):
                 devices.append([name, action_group])
 
         # No capable devices; don't show menu entry
@@ -164,8 +175,8 @@ class GSConnectShareExtension(GObject.Object, FileManager.MenuProvider):
 
         # Context Menu Item
         menu = FileManager.MenuItem(
-            name='GSConnectShareExtension::Devices',
-            label=_('Send To Mobile Device')
+            name="GSConnectShareExtension::Devices",
+            label=_("Send To Mobile Device"),
         )
 
         # Context Submenu
@@ -175,13 +186,11 @@ class GSConnectShareExtension(GObject.Object, FileManager.MenuProvider):
         # Context Submenu Items
         for name, action_group in devices:
             item = FileManager.MenuItem(
-                name='GSConnectShareExtension::Device' + name,
-                label=name
+                name="GSConnectShareExtension::Device" + name, label=name
             )
 
-            item.connect('activate', self.send_files, files, action_group)
+            item.connect("activate", self.send_files, files, action_group)
 
             submenu.append_item(item)
 
         return (menu,)
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.black]
+line-length = 80
+target-version = ['py36']
+include = 'nautilus-extension/.*\.py$'


### PR DESCRIPTION
This PR adds optional use of both the `black` and `flake8` commands to lint the Python code in `nautilus-extension/nautilus-gsconnect.py`. 

- The test setup is extended as usual: If either command is available, a <s>new test suite 'lint-python' is created.</s> test is added to the 'lint' suite for each available tool.
- Black configuration is in the root '/pyproject.toml' file
- flake8 configuration is in the root '/.flake8' file

A second commit checks in the necessary changes for our current code to pass both of these checks.

`black --check --diff` mode is used for scanning. It will not reformat the code, but will complain if it doesn't like the formatting, and output a diff of what it _would_ change if not prevented from doing so. (That diff will be truncated to the last 100 lines by the test runner, though.)

We could consider, in the future, having a local CI job that would just automatically reformat the code with `black` and commit the changes, to completely relieve humans of the code-style burden. (That's probably easier/better done by a repo Action than from inside the CI container.) Speaking of the container, I'll open a PR in the `gsconnect-ci` repo to add Python, black, and flake8 to the Docker image so the tests can be run there.

Some configuration adjustments are made on each linter, though they're kept to a minimum and for the most part the scans rely on the tools' built-in defaults. Linter configuration or tuning can be a subjective or even arbitrary thing, and both selection of linter tools and details of how they're configured are certainly open for discussion or refinement.

Configs applied by this PR:

1. Black is configured to enforce 80-character lines instead of its arbitrary 88, simply because I am personally baffled why anyone would want to impose a length constraint, but then choose one that still leaves the code unable to fit in an 80-character terminal without wrapping.
2. flake8 is configured to ignore E402, "module level import not at top of file", because it is impossible to pass that check if your code uses `gi.require_version()` before importing modules. (The individual lines could be annotated with overrides for the rule if we wanted to keep it in general, though.

----

This PR was largely inspired by #1510 from @busterbeam, with thanks for the nudge to address this. It's also motivated by the fact that we have very strict ESlint checking of the JavaScript, which makes it seem inconsistent that the Python code is allowed to just do its own thing. While I don't agree with _arbitrarily_ reformatting code based on user preferences, I'm all for **standardizing** code based on clear rules and mutually-adopted guidelines.
