### PR TITLE
editorconfig: Follow moved files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -26,7 +26,7 @@ indent_style = space
 indent_size = 2
 
 # WebExtension templates: 4-space indents
-[data/org.gnome.shell.extensions.gsconnect.json-{chrome,mozilla}]
+[data/webextension/*.in]
 indent_style = space
 indent_size = 4
 


### PR DESCRIPTION
Dumb little PR to update the .editorconfig file, so it looks for the `/data/webextension/` files in the correct place (and with the correct names).