### PR TITLE
Use addSettingsAction() to launch prefs

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -106,7 +106,9 @@ const ServiceToggle = GObject.registerClass({
         this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
 
         // Service Menu -> "Mobile Settings"
-        this.menu.addAction(_('Mobile Settings'), this._preferences);
+        this.menu.addSettingsAction(
+            _('Mobile Settings'),
+            'org.gnome.Shell.Extensions.GSConnect.Preferences.desktop');
 
         // Prime the service
         this._initService();
@@ -121,10 +123,6 @@ const ServiceToggle = GObject.registerClass({
         } catch (e) {
             logError(e, 'GSConnect');
         }
-    }
-
-    _preferences() {
-        Gio.Subprocess.new([`${Extension.path}/gsconnect-preferences`], 0);
     }
 
     _sync() {


### PR DESCRIPTION
`addSettingsAction()` takes the name of the desktop file for the preferences, and handles both launching the preferences executable and closing the system menu. Cleaner than calling `Subprocess.new()` directly to launch the preferences tool.

Fixes #1517