### PR TITLE
Nightly build updates (post-artifact changes)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,6 +57,6 @@ jobs:
       - name: Create and upload packaged artifact
         uses: actions/upload-artifact@v3
         with:
-          name: gsconnect@andyholmes.github.io.zip
+          name: gsconnect@andyholmes.github.io
           path: _build/gsconnect@andyholmes.github.io/
 

--- a/README.md
+++ b/README.md
@@ -64,5 +64,5 @@ See [Installing from Nightly Build][nightly-install] for installation instructio
 [help-wanted]: https://github.com/GSConnect/gnome-shell-extension-gsconnect/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22
 [needs-review]: https://github.com/GSConnect/gnome-shell-extension-gsconnect/pulls?q=is%3Apr+is%3Aopen+label%3A%22needs+review%22
 [people]: https://github.com/orgs/GSConnect/people
-[nightly-build]: https://nightly.link/GSConnect/gnome-shell-extension-gsconnect/workflows/main/main/test-build.zip
+[nightly-build]: https://nightly.link/GSConnect/gnome-shell-extension-gsconnect/workflows/main/main/gsconnect@andyholmes.github.io.zip
 [nightly-install]: https://github.com/GSConnect/gnome-shell-extension-gsconnect/wiki/Installation#install-from-nightly-build


### PR DESCRIPTION
This PR:
1. Renames the artifact output of the CI jobs to remove the `.zip` extension, which GitHub automatically appends (files were being served as `.zip.zip`)
1. Updates the nightly-build link in the `README.md` file to follow the new artifact name. (I've already fixed the Wiki link... assuming it's the only one there, anyway.)
