### PR TITLE
Keep license files out of webextension zips

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 
 _build
 *~
+webextension/*.zip
+

--- a/webextension/mkwebext.sh
+++ b/webextension/mkwebext.sh
@@ -23,14 +23,23 @@ elif [ "${1}" == "chrome" ] || [ "${1}" == "firefox" ]; then
 
     # Copy relevant files
     mkdir ${1}
-
     mkdir ${1}/images
-    cp -R js ${1}/
-    cp -R _locales ${1}/
+
     cp background.html ${1}/
     cp manifest.${1}.json ${1}/manifest.json
     cp popup.html ${1}/
     cp stylesheet.css ${1}/
+
+    mkdir ${1}/js
+    cp js/*.js ${1}/js/
+    cp js/*.map ${1}/js/
+
+    # Copy translations
+    for dir in ./_locales/*; do
+        localedest=${1}/_locales/$(basename ${dir})
+	mkdir -p ${localedest}
+	cp ${dir}/*.json ${localedest}/
+    done
 fi
 
 


### PR DESCRIPTION
This PR updates `webextension/mkwebext.sh` to ensure it doesn't suck the REUSE `.license` files into the output archives.

It also adds `webextension/*.zip` to the root `.gitignore`, for safety.