### PR TITLE
chore: disable blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
There's really no report that doesn't fall under one of the two templates, and we have more than enough abandoned `needs info` issues.