### PR TITLE
RunCommand Plugin: add default commands

### DIFF
--- a/data/org.gnome.Shell.Extensions.GSConnect.gschema.xml
+++ b/data/org.gnome.Shell.Extensions.GSConnect.gschema.xml
@@ -150,7 +150,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
   <schema id="org.gnome.Shell.Extensions.GSConnect.Plugin.Presenter"/>
   <schema id="org.gnome.Shell.Extensions.GSConnect.Plugin.RunCommand">
     <key name="command-list" type="a{sv}">
-      <default>{}</default>
+      <default><![CDATA[{'lock': <{'name': 'Lock', 'command': 'xdg-screensaver lock'}>, 'restart': <{'name': 'Restart', 'command': 'gnome-session-quit --reboot --force'}>, 'logout': <{'name': 'Log Out', 'command': 'gnome-session-quit --logout'}>, 'poweroff': <{'name': 'Power Off', 'command': 'gnome-session-quit --power-off --force'}>, 'suspend': <{'name': 'Suspend', 'command': 'systemctl suspend'}>}]]></default>
     </key>
   </schema>
   <schema id="org.gnome.Shell.Extensions.GSConnect.Plugin.SFTP">


### PR DESCRIPTION
Add preset commands for session and power management. Their names match those used by GNOME Desktop itself (e.g. "Power off" instead of "Shutdown", "Restart" instead of "Reboot", etc). Since the commands were added as a single line in the XML file, here's a more human-readable list of them:

| ID | Name | Command |
|----|------|---------|
|lock|Lock| `xdg-screensaver lock`|
|logout|Log Out| `gnome-session-quit --logout`|
|restart|Restart|`gnome-session-quit --reboot --force`|
|poweroff|Power Off| `gnome-session-quit --power-off --force` |
|suspend|Suspend| `systemctl suspend` |

I marked this as a draft because:

1. The command to suspend uses `systemctl`, but I'm not sure every GNOME Desktop installation has that available. From what I've researched, GNOME depends only on `systemd-logind` but I'm not sure if that is the systemd component that is providing the command I've used.
2. Is there a way to add line breaks such that we have one command per line? Showing everything in a single line doesn't look good and some text editors may have trouble syntax highlighting it.

fixes #1170.