### PR TITLE
Run Command Plugin: use systemctl for "Restart" and "Power Off" commands.

### DIFF
--- a/data/org.gnome.Shell.Extensions.GSConnect.gschema.xml
+++ b/data/org.gnome.Shell.Extensions.GSConnect.gschema.xml
@@ -150,7 +150,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
   <schema id="org.gnome.Shell.Extensions.GSConnect.Plugin.Presenter"/>
   <schema id="org.gnome.Shell.Extensions.GSConnect.Plugin.RunCommand">
     <key name="command-list" type="a{sv}">
-      <default><![CDATA[{'lock': <{'name': 'Lock', 'command': 'xdg-screensaver lock'}>, 'restart': <{'name': 'Restart', 'command': 'systemctl reboot'}>, 'logout': <{'name': 'Log Out', 'command': 'gnome-session-quit --logout'}>, 'poweroff': <{'name': 'Power Off', 'command': 'systemctl poweroff'}>, 'suspend': <{'name': 'Suspend', 'command': 'systemctl suspend'}>}]]></default>
+      <default><![CDATA[{'lock': <{'name': 'Lock', 'command': 'xdg-screensaver lock'}>, 'restart': <{'name': 'Restart', 'command': 'systemctl reboot'}>, 'logout': <{'name': 'Log Out', 'command': 'gnome-session-quit --logout --no-prompt'}>, 'poweroff': <{'name': 'Power Off', 'command': 'systemctl poweroff'}>, 'suspend': <{'name': 'Suspend', 'command': 'systemctl suspend'}>}]]></default>
     </key>
   </schema>
   <schema id="org.gnome.Shell.Extensions.GSConnect.Plugin.SFTP">

--- a/data/org.gnome.Shell.Extensions.GSConnect.gschema.xml
+++ b/data/org.gnome.Shell.Extensions.GSConnect.gschema.xml
@@ -150,7 +150,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
   <schema id="org.gnome.Shell.Extensions.GSConnect.Plugin.Presenter"/>
   <schema id="org.gnome.Shell.Extensions.GSConnect.Plugin.RunCommand">
     <key name="command-list" type="a{sv}">
-      <default><![CDATA[{'lock': <{'name': 'Lock', 'command': 'xdg-screensaver lock'}>, 'restart': <{'name': 'Restart', 'command': 'gnome-session-quit --reboot --force'}>, 'logout': <{'name': 'Log Out', 'command': 'gnome-session-quit --logout'}>, 'poweroff': <{'name': 'Power Off', 'command': 'gnome-session-quit --power-off --force'}>, 'suspend': <{'name': 'Suspend', 'command': 'systemctl suspend'}>}]]></default>
+      <default><![CDATA[{'lock': <{'name': 'Lock', 'command': 'xdg-screensaver lock'}>, 'restart': <{'name': 'Restart', 'command': 'systemctl reboot'}>, 'logout': <{'name': 'Log Out', 'command': 'gnome-session-quit --logout'}>, 'poweroff': <{'name': 'Power Off', 'command': 'systemctl poweroff'}>, 'suspend': <{'name': 'Suspend', 'command': 'systemctl suspend'}>}]]></default>
     </key>
   </schema>
   <schema id="org.gnome.Shell.Extensions.GSConnect.Plugin.SFTP">


### PR DESCRIPTION
This is a follow up to my previous PR, #1557.

Before this PR, the "Power Off", "Reboot", and "Log Out" commands displayed a confirmation dialog when ran. While this is a much welcome safety net when using the computer normally, it becomes annoying when running the commands remotely from a phone (requiring the user to go into Remote Input to click and confirm the operation).

Since we discussed it was okay to rely on systemd, I rewrote the commands for "Restart" and "Power Off" using `systemctl`.