### PR TITLE
Input Component: allow remote input in lockscreen

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -376,7 +376,7 @@ function disable() {
     serviceIndicator = null;
     Notification.unpatchGtkNotificationSources();
 
-    if (lockscreenInput){
+    if (lockscreenInput) {
         lockscreenInput.unpatchInhibitor();
         lockscreenInput = null;
     }

--- a/src/extension.js
+++ b/src/extension.js
@@ -340,6 +340,7 @@ class ServiceIndicator extends QuickSettings.SystemIndicator {
 });
 
 var serviceIndicator = null;
+var lockscreenInput = null;
 
 function init() {
     // If installed as a user extension, this will install the Desktop entry,
@@ -360,7 +361,6 @@ function init() {
     Clipboard.watchService();
 }
 
-var lockscreenInput = null;
 
 function enable() {
     serviceIndicator = new ServiceIndicator();

--- a/src/extension.js
+++ b/src/extension.js
@@ -25,6 +25,7 @@ const Config = Extension.imports.config;
 const Device = Extension.imports.shell.device;
 const Keybindings = Extension.imports.shell.keybindings;
 const Notification = Extension.imports.shell.notification;
+const Input = Extension.imports.shell.input;
 const Remote = Extension.imports.utils.remote;
 
 Extension.getIcon = Utils.getIcon;
@@ -359,10 +360,14 @@ function init() {
     Clipboard.watchService();
 }
 
+var lockscreenInput = null;
 
 function enable() {
     serviceIndicator = new ServiceIndicator();
     Notification.patchGtkNotificationSources();
+
+    lockscreenInput = new Input.LockscreenRemoteAccess();
+    lockscreenInput.patchInhibitor();
 }
 
 
@@ -370,4 +375,9 @@ function disable() {
     serviceIndicator.destroy();
     serviceIndicator = null;
     Notification.unpatchGtkNotificationSources();
+
+    if (lockscreenInput){
+        lockscreenInput.unpatchInhibitor();
+        lockscreenInput = null;
+    }
 }

--- a/src/shell/input.js
+++ b/src/shell/input.js
@@ -11,7 +11,7 @@ const Config = Extension.imports.config;
 
 var LockscreenRemoteAccess = class LockscreenRemoteAccess {
 
-    constructor(){
+    constructor() {
         this._inhibitor = null;
         this._settings = new Gio.Settings({
             settings_schema: Config.GSCHEMA.lookup(
@@ -22,20 +22,20 @@ var LockscreenRemoteAccess = class LockscreenRemoteAccess {
         });
     }
 
-    patchInhibitor(){
+    patchInhibitor() {
         if (this._inhibitor)
             return;
 
-        if (this._settings.get_boolean('keep-alive-when-locked')){
+        if (this._settings.get_boolean('keep-alive-when-locked')) {
             this._inhibitor = global.backend.get_remote_access_controller().inhibit_remote_access;
             global.backend.get_remote_access_controller().inhibit_remote_access = () => {};
         }
     }
 
-    unpatchInhibitor(){
+    unpatchInhibitor() {
         if (!this._inhibitor)
             return;
         global.backend.get_remote_access_controller().inhibit_remote_access = this._inhibitor;
         this._inhibitor = null;
     }
-}
+};

--- a/src/shell/input.js
+++ b/src/shell/input.js
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: GSConnect Developers https://github.com/GSConnect
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+'use strict';
+
+const Gio = imports.gi.Gio;
+const Extension = imports.misc.extensionUtils.getCurrentExtension();
+
+const Config = Extension.imports.config;
+
+var LockscreenRemoteAccess = class LockscreenRemoteAccess {
+
+    constructor(){
+        this._inhibitor = null;
+        this._settings = new Gio.Settings({
+            settings_schema: Config.GSCHEMA.lookup(
+                'org.gnome.Shell.Extensions.GSConnect',
+                null
+            ),
+            path: '/org/gnome/shell/extensions/gsconnect/',
+        });
+    }
+
+    patchInhibitor(){
+        if (this._inhibitor)
+            return;
+
+        if (this._settings.get_boolean('keep-alive-when-locked')){
+            this._inhibitor = global.backend.get_remote_access_controller().inhibit_remote_access;
+            global.backend.get_remote_access_controller().inhibit_remote_access = () => {};
+        }
+    }
+
+    unpatchInhibitor(){
+        if (!this._inhibitor)
+            return;
+        global.backend.get_remote_access_controller().inhibit_remote_access = this._inhibitor;
+        this._inhibitor = null;
+    }
+}


### PR DESCRIPTION
If the user enables the preference to "Keep Alive" while the screen is locked, it will be possible to remote input in the lockscreen. This was implemented by overriding the function that inhibits such access in the lockscreen (if said preference is enabled).

This was based on the work of the author of the extension "Allow Locked Remote Desktop", who implemented a very similar feature in his own program.

If merged, this would solve issue #1238.

Thanks for developing GSConnect!  📱🔄💻  