### PR TITLE
Port to gnome 44

### DIFF
--- a/data/metadata.json.in
+++ b/data/metadata.json.in
@@ -3,6 +3,6 @@
     "name": "GSConnect",
     "description": "GSConnect is a complete implementation of KDE Connect especially for GNOME Shell with Nautilus, Chrome and Firefox integration. It does not rely on the KDE Connect desktop application and will not work with it installed.\n\nKDE Connect allows devices to securely share content like notifications or files and other features like SMS messaging and remote control. The KDE Connect team has applications for Linux, BSD, Android, Sailfish, iOS, macOS and Windows.\n\nPlease report issues on Github!",
     "version": @PACKAGE_VERSION@,
-    "shell-version": [ "43", "44" ],
+    "shell-version": [ "44" ],
     "url": "@PACKAGE_URL@/wiki"
 }

--- a/data/metadata.json.in
+++ b/data/metadata.json.in
@@ -3,6 +3,6 @@
     "name": "GSConnect",
     "description": "GSConnect is a complete implementation of KDE Connect especially for GNOME Shell with Nautilus, Chrome and Firefox integration. It does not rely on the KDE Connect desktop application and will not work with it installed.\n\nKDE Connect allows devices to securely share content like notifications or files and other features like SMS messaging and remote control. The KDE Connect team has applications for Linux, BSD, Android, Sailfish, iOS, macOS and Windows.\n\nPlease report issues on Github!",
     "version": @PACKAGE_VERSION@,
-    "shell-version": [ "43" ],
+    "shell-version": [ "43", "44" ],
     "url": "@PACKAGE_URL@/wiki"
 }

--- a/src/extension.js
+++ b/src/extension.js
@@ -329,6 +329,12 @@ class ServiceIndicator extends QuickSettings.SystemIndicator {
         // Add the indicator to the panel and the toggle to the menu
         QuickSettingsMenu._indicators.insert_child_at_index(this, 0);
         QuickSettingsMenu._addItems(this.quickSettingsItems);
+
+        // Ensure the tile(s) are above the background apps menu
+        for (const item of this.quickSettingsItems) {
+            QuickSettingsMenu.menu._grid.set_child_below_sibling(item,
+                QuickSettingsMenu._backgroundApps.quickSettingsItems[0]);
+        }
     }
 
     destroy() {

--- a/src/extension.js
+++ b/src/extension.js
@@ -41,7 +41,7 @@ const ServiceToggle = GObject.registerClass({
 
     _init() {
         super._init({
-            label: 'GSConnect',
+            title: 'GSConnect',
             iconName: 'org.gnome.Shell.Extensions.GSConnect-symbolic',
             toggleMode: true,
         });

--- a/src/extension.js
+++ b/src/extension.js
@@ -45,7 +45,7 @@ const ServiceToggle = GObject.registerClass({
             toggleMode: true,
         });
 
-        this.set({iconName: 'org.gnome.Shell.Extensions.GSConnect-symbolic'})
+        this.set({iconName: 'org.gnome.Shell.Extensions.GSConnect-symbolic'});
 
         // Set QuickMenuToggle header.
         this.menu.setHeader('org.gnome.Shell.Extensions.GSConnect-symbolic', 'GSConnect',

--- a/src/extension.js
+++ b/src/extension.js
@@ -42,9 +42,10 @@ const ServiceToggle = GObject.registerClass({
     _init() {
         super._init({
             title: 'GSConnect',
-            iconName: 'org.gnome.Shell.Extensions.GSConnect-symbolic',
             toggleMode: true,
         });
+
+        this.set({iconName: 'org.gnome.Shell.Extensions.GSConnect-symbolic'})
 
         // Set QuickMenuToggle header.
         this.menu.setHeader('org.gnome.Shell.Extensions.GSConnect-symbolic', 'GSConnect',

--- a/src/shell/utils.js
+++ b/src/shell/utils.js
@@ -24,9 +24,9 @@ function getIcon(name) {
         // Setup the desktop icons
         const settings = imports.gi.St.Settings.get();
         getIcon._desktop = new imports.gi.Gtk.IconTheme();
-        getIcon._desktop.set_custom_theme(settings.gtk_icon_theme);
+        getIcon._desktop.set_theme_name(settings.gtk_icon_theme);
         settings.connect('notify::gtk-icon-theme', (settings_, key_) => {
-            getIcon._desktop.set_custom_theme(settings_.gtk_icon_theme);
+            getIcon._desktop.set_theme_name(settings_.gtk_icon_theme);
         });
 
         // Preload our fallbacks


### PR DESCRIPTION
This patch intends to add support for gnome 44 and is very much work in progress. If you don't want WIP PRs in the repo, I'll happily retract it and submit when I'm ready. I don't have much experience with contributing to open source, not 100% sure about the ins and outs.

Status of the PR:
- [x] Extension installable on Gnome 44
- [x] QuickToggle looks as on Gnome 43
- [x] Quick toggle will be rendered above the background apps menu
- [x] No suspicious gnome-shell warnings logged when manually testing the extension

:exclamation: <del>The QuickToggle is appended _after_ the 'Background Apps' menu item. This looks rather weird, but not outlandish. </del>

<del>:exclamation: The QuickToggle is missing the icon it once had. I'm still looking into how it was originally displayed and how to bring it back.</del>

Solves #1573