### PR TITLE
Update QuickMenuToggle header to Devices

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -48,7 +48,7 @@ const ServiceToggle = GObject.registerClass({
         this.set({iconName: 'org.gnome.Shell.Extensions.GSConnect-symbolic'});
 
         // Set QuickMenuToggle header.
-        this.menu.setHeader('org.gnome.Shell.Extensions.GSConnect-symbolic', 'GSConnect',
+        this.menu.setHeader('org.gnome.Shell.Extensions.GSConnect-symbolic', 'Devices',
             _('Sync between your devices'));
 
         this._menus = {};


### PR DESCRIPTION
Change the GSConnect label in Quick settings toggle to just Devices, similar to Valent's gnome extension https://github.com/andyholmes/gnome-shell-extension-valent/blob/e7f759047c45833cd211ef18a8554008cb1b8b12/src/extension/status.js#L255 This makes it look better integrated with the system.