### PR TITLE
Add startup permissions checks

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -364,6 +364,14 @@ var serviceIndicator = null;
 var lockscreenInput = null;
 
 function init() {
+    // If installed as a user extension, this checks the permissions
+    // on certain critical files in the extension directory
+    // to ensure that they have the executable bit set,
+    // and makes them executable if not. Some packaging methods
+    // (particularly GitHub Actions artifacts) automatically remove
+    // executable bits from all contents, presumably for security.
+    Utils.ensurePermissions();
+
     // If installed as a user extension, this will install the Desktop entry,
     // DBus and systemd service files necessary for DBus activation and
     // GNotifications. Since there's no uninit()/uninstall() hook for extensions

--- a/src/shell/utils.js
+++ b/src/shell/utils.js
@@ -128,6 +128,55 @@ function _installResource(dirname, basename, relativePath) {
     }
 }
 
+/**
+ * Use Gio.File to ensure a file's executable bits are set.
+ *
+ * @param {string} filepath - An absolute path to a file
+ * @returns {boolean} - True if the file already was, or is now, executable
+ */
+function _setExecutable(filepath) {
+    try {
+        const file = Gio.File.new_for_path(filepath);
+        const finfo = file.query_info(
+            `${Gio.FILE_ATTRIBUTE_STANDARD_TYPE},${Gio.FILE_ATTRIBUTE_UNIX_MODE}`,
+            Gio.FileQueryInfoFlags.NO_FOLLOW_SYMLINKS,
+            null);
+
+        if (!finfo.has_attribute(Gio.FILE_ATTRIBUTE_UNIX_MODE))
+            return false;
+
+        const mode = finfo.get_attribute_uint32(
+            Gio.FILE_ATTRIBUTE_UNIX_MODE);
+        const new_mode = (mode | 0o111);
+        if (mode === new_mode)
+            return true;
+
+        return file.set_attribute_uint32(
+            Gio.FILE_ATTRIBUTE_UNIX_MODE,
+            new_mode,
+            Gio.FileQueryInfoFlags.NO_FOLLOW_SYMLINKS,
+            null);
+    } catch (e) {
+        logError(e, 'GSConnect');
+        return false;
+    }
+}
+
+/**
+ * Ensure critical files in the extension directory have the
+ * correct permissions.
+ */
+function ensurePermissions() {
+    if (Config.IS_USER) {
+        const executableFiles = [
+            'gsconnect-preferences',
+            'service/daemon.js',
+            'service/nativeMessagingHost.js',
+        ];
+        for (const file of executableFiles)
+            _setExecutable(GLib.build_filenamev([Extension.path, file]));
+    }
+}
 
 /**
  * Install the files necessary for the GSConnect service to run.
@@ -221,4 +270,3 @@ function installService() {
             GLib.unlink(GLib.build_filenamev([manifest[0], manifestFile]));
     }
 }
-


### PR DESCRIPTION
Over in discussion #1586, when @aplumez attempted to use one of the GitHub Actions artifact zip files as a GSConnect installer, we discovered that there's an issue with file permissions. It seems that GitHub strips the executable bit off of all the files it adds to the artifact zip. That causes the installed GSConnect not to be able to launch its preferences, or start `daemon.js` or `nativeMessagingHost.js`

Since installable Artifacts are still a very useful testing tool, this PR addresses the issue with an additional check performed during the extension `_init()`: `Utils.ensurePermissions()`. Analogous to the existing `Utils.installService()` call, `ensurePermissions()` will (iff the extension is installed as a user extension) check the executable bits on those three files, and if they're not set, will attempt to set them.

Doing that startup check ensures that a GSConnect installed from a GitHub Artifacts zip, or one that's been misinstalled through some other means, will be made functional again, instead of creating difficult-to-diagnose problems.