### PR TITLE
Use a more descriptive label for extension-wide keepalive setting

### DIFF
--- a/data/ui/preferences-window.ui
+++ b/data/ui/preferences-window.ui
@@ -370,18 +370,6 @@ SPDX-License-Identifier: GPL-2.0-or-later
                             <property name="margin_bottom">20</property>
                             <property name="spacing">24</property>
                             <child>
-                              <object class="GtkLabel" id="keep-alive-when-locked-label">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="halign">start</property>
-                                <property name="margin_bottom">12</property>
-                                <property name="label" translatable="yes">GSConnect remains active when GNOME Shell is locked</property>
-                                <accessibility>
-                                  <relation type="label-for" target="keep-alive-when-locked"/>
-                                </accessibility>
-                              </object>
-                            </child>
-                            <child>
                               <object class="GtkSwitch" id="keep-alive-when-locked">
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
@@ -390,6 +378,18 @@ SPDX-License-Identifier: GPL-2.0-or-later
                                 <property name="action_name">win.keep-alive-when-locked</property>
                                 <accessibility>
                                   <relation type="labelled-by" target="keep-alive-when-locked-label"/>
+                                </accessibility>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="keep-alive-when-locked-label">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="halign">start</property>
+                                <property name="margin_bottom">12</property>
+                                <property name="label" translatable="yes">GSConnect remains active when GNOME Shell is locked</property>
+                                <accessibility>
+                                  <relation type="label-for" target="keep-alive-when-locked"/>
                                 </accessibility>
                               </object>
                             </child>

--- a/data/ui/preferences-window.ui
+++ b/data/ui/preferences-window.ui
@@ -82,7 +82,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
     <property name="can_focus">False</property>
     <property name="icon_name">org.gnome.Shell.Extensions.GSConnect-symbolic</property>
     <property name="default_width">640</property>
-    <property name="default_height">440</property>
+    <property name="default_height">460</property>
     <child type="titlebar">
       <object class="GtkHeaderBar" id="headerbar">
         <property name="visible">True</property>

--- a/data/ui/preferences-window.ui
+++ b/data/ui/preferences-window.ui
@@ -345,12 +345,12 @@ SPDX-License-Identifier: GPL-2.0-or-later
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkLabel" id="behavior-when-locked-label">
+                          <object class="GtkLabel" id="extension-settings-label">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="halign">start</property>
                             <property name="margin_bottom">12</property>
-                            <property name="label" translatable="yes">Behavior When Locked</property>
+                            <property name="label" translatable="yes">Extension Settings</property>
                             <attributes>
                               <attribute name="weight" value="bold"/>
                             </attributes>
@@ -362,7 +362,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkBox" id="behavior-when-locked-box">
+                          <object class="GtkBox" id="extension-settings-box">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="margin_left">12</property>
@@ -375,7 +375,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
                                 <property name="can_focus">False</property>
                                 <property name="halign">start</property>
                                 <property name="margin_bottom">12</property>
-                                <property name="label" translatable="yes">Keep Alive</property>
+                                <property name="label" translatable="yes">GSConnect remains active when GNOME Shell is locked</property>
                                 <accessibility>
                                   <relation type="label-for" target="keep-alive-when-locked"/>
                                 </accessibility>

--- a/po/org.gnome.Shell.Extensions.GSConnect.pot
+++ b/po/org.gnome.Shell.Extensions.GSConnect.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.gnome.Shell.Extensions.GSConnect\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-22 10:01+0530\n"
+"POT-Creation-Date: 2023-04-29 00:46-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -81,7 +81,7 @@ msgstr ""
 msgid "And more…"
 msgstr ""
 
-#: data/metainfo/org.gnome.Shell.Extensions.GSConnect.metainfo.xml.in:127
+#: data/metainfo/org.gnome.Shell.Extensions.GSConnect.metainfo.xml.in:130
 msgid "GSConnect in GNOME Shell"
 msgstr ""
 
@@ -508,11 +508,11 @@ msgid "Searching for devices…"
 msgstr ""
 
 #: data/ui/preferences-window.ui:353
-msgid "Behavior When Locked"
+msgid "Extension Settings"
 msgstr ""
 
 #: data/ui/preferences-window.ui:378
-msgid "Keep Alive"
+msgid "GSConnect remains active when GNOME Shell is locked"
 msgstr ""
 
 #: data/ui/preferences-window.ui:410


### PR DESCRIPTION
The renamed section title is based on the expectation that there could be other extension-wide settings, eventually.

![image](https://user-images.githubusercontent.com/538020/235294631-6aa881c3-c70d-48b6-8c7f-6787ee470c74.png)


Fixes #1613 