### PR TITLE
Create a GNOME 43 branch, and backport recent commits

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,9 +8,11 @@ on:
   push:
     branches:
       - main
+      - gnome-43
   pull_request:
     branches:
       - main
+      - gnome-43
   workflow_dispatch:
 
 jobs:

--- a/src/extension.js
+++ b/src/extension.js
@@ -343,6 +343,14 @@ var serviceIndicator = null;
 var lockscreenInput = null;
 
 function init() {
+    // If installed as a user extension, this checks the permissions
+    // on certain critical files in the extension directory
+    // to ensure that they have the executable bit set,
+    // and makes them executable if not. Some packaging methods
+    // (particularly GitHub Actions artifacts) automatically remove
+    // executable bits from all contents, presumably for security.
+    Utils.ensurePermissions();
+
     // If installed as a user extension, this will install the Desktop entry,
     // DBus and systemd service files necessary for DBus activation and
     // GNotifications. Since there's no uninit()/uninstall() hook for extensions

--- a/src/shell/utils.js
+++ b/src/shell/utils.js
@@ -128,6 +128,55 @@ function _installResource(dirname, basename, relativePath) {
     }
 }
 
+/**
+ * Use Gio.File to ensure a file's executable bits are set.
+ *
+ * @param {string} filepath - An absolute path to a file
+ * @returns {boolean} - True if the file already was, or is now, executable
+ */
+function _setExecutable(filepath) {
+    try {
+        const file = Gio.File.new_for_path(filepath);
+        const finfo = file.query_info(
+            `${Gio.FILE_ATTRIBUTE_STANDARD_TYPE},${Gio.FILE_ATTRIBUTE_UNIX_MODE}`,
+            Gio.FileQueryInfoFlags.NO_FOLLOW_SYMLINKS,
+            null);
+
+        if (!finfo.has_attribute(Gio.FILE_ATTRIBUTE_UNIX_MODE))
+            return false;
+
+        const mode = finfo.get_attribute_uint32(
+            Gio.FILE_ATTRIBUTE_UNIX_MODE);
+        const new_mode = (mode | 0o111);
+        if (mode === new_mode)
+            return true;
+
+        return file.set_attribute_uint32(
+            Gio.FILE_ATTRIBUTE_UNIX_MODE,
+            new_mode,
+            Gio.FileQueryInfoFlags.NO_FOLLOW_SYMLINKS,
+            null);
+    } catch (e) {
+        logError(e, 'GSConnect');
+        return false;
+    }
+}
+
+/**
+ * Ensure critical files in the extension directory have the
+ * correct permissions.
+ */
+function ensurePermissions() {
+    if (Config.IS_USER) {
+        const executableFiles = [
+            'gsconnect-preferences',
+            'service/daemon.js',
+            'service/nativeMessagingHost.js',
+        ];
+        for (const file of executableFiles)
+            _setExecutable(GLib.build_filenamev([Extension.path, file]));
+    }
+}
 
 /**
  * Install the files necessary for the GSConnect service to run.
@@ -221,4 +270,3 @@ function installService() {
             GLib.unlink(GLib.build_filenamev([manifest[0], manifestFile]));
     }
 }
-


### PR DESCRIPTION
(Well, OK, I already created the _branch_, so that I could target it here.)

This PR backports (by simple cherry-pick; no further changes were necessary) into the `gnome-43` branch all three commits which made changes to functionality, since the first GNOME 44-only commits were introduced to the `main` branch. (The commit immediately prior to the first such change is the branch point.)

It also enables `main.yml` CI runs on pushes and PRs targeting that branch.