### PR TITLE
Add gnome-43 branch to (main.yml) CI runs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,9 +8,11 @@ on:
   push:
     branches:
       - main
+      - gnome-43
   pull_request:
     branches:
       - main
+      - gnome-43
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Submitting this again (see #1616), but targeting the _`main`_ branch like I should've done in the first place.