### PR TITLE
nautilus: Use str(e) to report exception

### DIFF
--- a/nautilus-extension/nautilus-gsconnect.py
+++ b/nautilus-extension/nautilus-gsconnect.py
@@ -57,7 +57,7 @@ try:
     _ = i18n.gettext
 
 except (IOError, OSError) as e:
-    print("GSConnect: {0}".format(e.strerror))
+    print("GSConnect: {0}".format(str(e)))
     i18n = gettext.translation(
         SERVICE_NAME, localedir=LOCALE_DIR, fallback=True
     )


### PR DESCRIPTION
It's a stuupid little thing, but...

* `e.strerror` gives just the error string, e.g.
    ```python
    e.strerror == 'No such file or directory'
    ```

* `str(e)` creates a nicely-formatted message, e.g.
    ```python
    str(e) == "[Errno 2] No such file or directory: '__some_path__'"
    ```
