### PR TITLE
preferences-window: Improve the description of the "keep alive" option

### DIFF
--- a/data/ui/preferences-window.ui
+++ b/data/ui/preferences-window.ui
@@ -387,7 +387,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
                                 <property name="can_focus">False</property>
                                 <property name="halign">start</property>
                                 <property name="margin_bottom">12</property>
-                                <property name="label" translatable="yes">GSConnect remains active when GNOME Shell is locked</property>
+                                <property name="label" translatable="yes">Keep GSConnect active when this device is locked</property>
                                 <accessibility>
                                   <relation type="label-for" target="keep-alive-when-locked"/>
                                 </accessibility>


### PR DESCRIPTION
Follow-up from https://github.com/automerisnaranja/gnome-shell-extension-gsconnect/commit/45e13005170289ff6f04abc6f491ea439e9e9d6d

The option description is currently phrased as "GSConnect remains active when GNOME Shell is locked". However, this text has 2 problems:

- Options descriptions are usually phrased in the imperative mood, but this one isn't
- "GNOME Shell" can be a technical term for people who don't know what a shell is

This change addresses the 2 problems above by using "Keep GSConnect active when this device is locked".

Fixes https://github.com/GSConnect/gnome-shell-extension-gsconnect/issues/1613#issuecomment-1561984145