### PR TITLE
GSconnect vulnerable to man-in-the-middle attack due to compatibility [Potential Fix] 

### DIFF
--- a/src/service/daemon.js
+++ b/src/service/daemon.js
@@ -8,7 +8,7 @@
 
 // Allow TLSv1.0 certificates
 // See https://github.com/GSConnect/gnome-shell-extension-gsconnect/issues/930
-imports.gi.GLib.setenv('G_TLS_GNUTLS_PRIORITY', 'NORMAL:%COMPAT:+VERS-TLS1.0', true);
+imports.gi.GLib.setenv('G_TLS_GNUTLS_PRIORITY', 'NORMAL:%COMPAT:+VERS-ALL', true);
 
 imports.gi.versions.Gdk = '3.0';
 imports.gi.versions.GdkPixbuf = '2.0';


### PR DESCRIPTION
I enable all version of TLS like in https://invent.kde.org/network/kdeconnect-android/-/commit/e2dbc39e3a73cc6c7cf1c27362e4f2b768e88f42

It's my first contribution.

This PR can fix #1606