### PR TITLE
refactor: port to `Gio._promisify()`

### DIFF
--- a/src/service/__init__.js
+++ b/src/service/__init__.js
@@ -14,6 +14,46 @@ const GLib = imports.gi.GLib;
 const Config = imports.config;
 
 
+// Promise Wrappers
+try {
+    const {EBook, EDataServer} = imports.gi;
+
+    Gio._promisify(EBook.BookClient, 'connect');
+    Gio._promisify(EBook.BookClient.prototype, 'get_view');
+    Gio._promisify(EBook.BookClient.prototype, 'get_contacts');
+    Gio._promisify(EDataServer.SourceRegistry, 'new');
+} finally {
+    // Silence import errors
+}
+
+Gio._promisify(Gio.AsyncInitable.prototype, 'init_async');
+Gio._promisify(Gio.DBusConnection.prototype, 'call');
+Gio._promisify(Gio.DBusProxy.prototype, 'call');
+Gio._promisify(Gio.DataInputStream.prototype, 'read_line_async',
+    'read_line_finish_utf8');
+Gio._promisify(Gio.File.prototype, 'delete_async');
+Gio._promisify(Gio.File.prototype, 'enumerate_children_async');
+Gio._promisify(Gio.File.prototype, 'load_contents_async');
+Gio._promisify(Gio.File.prototype, 'mount_enclosing_volume');
+Gio._promisify(Gio.File.prototype, 'query_info_async');
+Gio._promisify(Gio.File.prototype, 'read_async');
+Gio._promisify(Gio.File.prototype, 'replace_async');
+Gio._promisify(Gio.File.prototype, 'replace_contents_bytes_async',
+    'replace_contents_finish');
+Gio._promisify(Gio.FileEnumerator.prototype, 'next_files_async');
+Gio._promisify(Gio.Mount.prototype, 'unmount_with_operation');
+Gio._promisify(Gio.InputStream.prototype, 'close_async');
+Gio._promisify(Gio.OutputStream.prototype, 'close_async');
+Gio._promisify(Gio.OutputStream.prototype, 'splice_async');
+Gio._promisify(Gio.OutputStream.prototype, 'write_all_async');
+Gio._promisify(Gio.SocketClient.prototype, 'connect_async');
+Gio._promisify(Gio.SocketListener.prototype, 'accept_async');
+Gio._promisify(Gio.Subprocess.prototype, 'communicate_utf8_async');
+Gio._promisify(Gio.Subprocess.prototype, 'wait_check_async');
+Gio._promisify(Gio.TlsConnection.prototype, 'handshake_async');
+Gio._promisify(Gio.DtlsConnection.prototype, 'handshake_async');
+
+
 // User Directories
 Config.CACHEDIR = GLib.build_filenamev([GLib.get_user_cache_dir(), 'gsconnect']);
 Config.CONFIGDIR = GLib.build_filenamev([GLib.get_user_config_dir(), 'gsconnect']);

--- a/src/service/components/clipboard.js
+++ b/src/service/components/clipboard.js
@@ -64,8 +64,11 @@ var Clipboard = GObject.registerClass({
         if (this._clipboard instanceof Gtk.Clipboard)
             this._clipboard.set_text(content, -1);
 
-        if (this._clipboard instanceof Gio.DBusProxy)
-            this._proxySetText(content);
+        if (this._clipboard instanceof Gio.DBusProxy) {
+            this._clipboard.call('SetText', new GLib.Variant('(s)', [content]),
+                Gio.DBusCallFlags.NO_AUTO_START, -1, this._cancellable)
+                .catch(debug);
+        }
     }
 
     async _onNameAppeared(connection, name, name_owner) {
@@ -85,24 +88,11 @@ var Clipboard = GObject.registerClass({
                 g_flags: Gio.DBusProxyFlags.DO_NOT_LOAD_PROPERTIES,
             });
 
-            await new Promise((resolve, reject) => {
-                this._clipboard.init_async(
-                    GLib.PRIORITY_DEFAULT,
-                    this._cancellable,
-                    (proxy, res) => {
-                        try {
-                            resolve(proxy.init_finish(res));
-                        } catch (e) {
-                            reject(e);
-                        }
-                    }
-                );
-            });
+            await this._clipboard.init_async(GLib.PRIORITY_DEFAULT,
+                this._cancellable);
 
-            this._ownerChangeId = this._clipboard.connect(
-                'g-signal',
-                this._onOwnerChange.bind(this)
-            );
+            this._ownerChangeId = this._clipboard.connect('g-signal',
+                this._onOwnerChange.bind(this));
 
             this._onOwnerChange();
             if (!globalThis.HAVE_GNOME) {
@@ -135,10 +125,8 @@ var Clipboard = GObject.registerClass({
         const display = Gdk.Display.get_default();
         this._clipboard = Gtk.Clipboard.get_default(display);
 
-        this._ownerChangeId = this._clipboard.connect(
-            'owner-change',
-            this._onOwnerChange.bind(this)
-        );
+        this._ownerChangeId = this._clipboard.connect('owner-change',
+            this._onOwnerChange.bind(this));
 
         this._onOwnerChange();
     }
@@ -167,68 +155,10 @@ var Clipboard = GObject.registerClass({
     /*
      * Proxy Clipboard
      */
-    _proxyGetMimetypes() {
-        return new Promise((resolve, reject) => {
-            this._clipboard.call(
-                'GetMimetypes',
-                null,
-                Gio.DBusCallFlags.NO_AUTO_START,
-                -1,
-                this._cancellable,
-                (proxy, res) => {
-                    try {
-                        const reply = proxy.call_finish(res);
-                        resolve(reply.deepUnpack()[0]);
-                    } catch (e) {
-                        Gio.DBusError.strip_remote_error(e);
-                        reject(e);
-                    }
-                }
-            );
-        });
-    }
-
-    _proxyGetText() {
-        return new Promise((resolve, reject) => {
-            this._clipboard.call(
-                'GetText',
-                null,
-                Gio.DBusCallFlags.NO_AUTO_START,
-                -1,
-                this._cancellable,
-                (proxy, res) => {
-                    try {
-                        const reply = proxy.call_finish(res);
-                        resolve(reply.deepUnpack()[0]);
-                    } catch (e) {
-                        Gio.DBusError.strip_remote_error(e);
-                        reject(e);
-                    }
-                }
-            );
-        });
-    }
-
-    _proxySetText(text) {
-        this._clipboard.call(
-            'SetText',
-            new GLib.Variant('(s)', [text]),
-            Gio.DBusCallFlags.NO_AUTO_START,
-            -1,
-            this._cancellable,
-            (proxy, res) => {
-                try {
-                    proxy.call_finish(res);
-                } catch (e) {
-                    Gio.DBusError.strip_remote_error(e);
-                    debug(e);
-                }
-            }
-        );
-    }
-
     async _proxyUpdateText() {
-        const mimetypes = await this._proxyGetMimetypes();
+        let reply = await this._clipboard.call('GetMimetypes', null,
+            Gio.DBusCallFlags.NO_AUTO_START, -1, this._cancellable);
+        const mimetypes = reply.deepUnpack()[0];
 
         // Special case for a cleared clipboard
         if (mimetypes.length === 0)
@@ -238,7 +168,9 @@ var Clipboard = GObject.registerClass({
         if (mimetypes.includes('text/uri-list'))
             return;
 
-        const text = await this._proxyGetText();
+        reply = await this._clipboard.call('GetText', null,
+            Gio.DBusCallFlags.NO_AUTO_START, -1, this._cancellable);
+        const text = reply.deepUnpack()[0];
 
         this._applyUpdate(text);
     }
@@ -246,20 +178,10 @@ var Clipboard = GObject.registerClass({
     /*
      * GtkClipboard
      */
-    _gtkGetMimetypes() {
-        return new Promise((resolve, reject) => {
+    async _gtkUpdateText() {
+        const mimetypes = await new Promise((resolve, reject) => {
             this._clipboard.request_targets((clipboard, atoms) => resolve(atoms));
         });
-    }
-
-    _gtkGetText() {
-        return new Promise((resolve, reject) => {
-            this._clipboard.request_text((clipboard, text) => resolve(text));
-        });
-    }
-
-    async _gtkUpdateText() {
-        const mimetypes = await this._gtkGetMimetypes();
 
         // Special case for a cleared clipboard
         if (mimetypes.length === 0)
@@ -269,7 +191,9 @@ var Clipboard = GObject.registerClass({
         if (mimetypes.includes('text/uri-list'))
             return;
 
-        const text = await this._gtkGetText();
+        const text = await new Promise((resolve, reject) => {
+            this._clipboard.request_text((clipboard, text) => resolve(text));
+        });
 
         this._applyUpdate(text);
     }
@@ -292,7 +216,6 @@ var Clipboard = GObject.registerClass({
 
         if (!globalThis.HAVE_GNOME && this.signalHandler)
             Gio.DBus.session.signal_unsubscribe(this.signalHandler);
-
     }
 });
 

--- a/src/service/components/contacts.js
+++ b/src/service/components/contacts.js
@@ -125,58 +125,6 @@ var Store = GObject.registerClass({
     }
 
     /*
-     * EDS Helpers
-     */
-    _getEBookClient(source, cancellable = null) {
-        return new Promise((resolve, reject) => {
-            EBook.BookClient.connect(source, 0, cancellable, (source, res) => {
-                try {
-                    resolve(EBook.BookClient.connect_finish(res));
-                } catch (e) {
-                    reject(e);
-                }
-            });
-        });
-    }
-
-    _getEBookView(client, query = '', cancellable = null) {
-        return new Promise((resolve, reject) => {
-            client.get_view(query, cancellable, (client, res) => {
-                try {
-                    resolve(client.get_view_finish(res)[1]);
-                } catch (e) {
-                    reject(e);
-                }
-            });
-        });
-    }
-
-    _getEContacts(client, query = '', cancellable = null) {
-        return new Promise((resolve, reject) => {
-            client.get_contacts(query, cancellable, (client, res) => {
-                try {
-                    resolve(client.get_contacts_finish(res)[1]);
-                } catch (e) {
-                    debug(e);
-                    resolve([]);
-                }
-            });
-        });
-    }
-
-    _getESourceRegistry(cancellable = null) {
-        return new Promise((resolve, reject) => {
-            EDataServer.SourceRegistry.new(cancellable, (registry, res) => {
-                try {
-                    resolve(EDataServer.SourceRegistry.new_finish(res));
-                } catch (e) {
-                    reject(e);
-                }
-            });
-        });
-    }
-
-    /*
      * AddressBook DBus callbacks
      */
     _onObjectsAdded(connection, sender, path, iface, signal, params) {
@@ -240,8 +188,8 @@ var Store = GObject.registerClass({
         try {
             // Get an EBookClient and EBookView
             const uid = source.get_uid();
-            const client = await this._getEBookClient(source);
-            const view = await this._getEBookView(client, 'exists "tel"');
+            const client = await EBook.BookClient.connect(source, null);
+            const [view] = await client.get_view('exists "tel"', null);
 
             // Watch the view for changes to the address book
             const connection = view.get_connection();
@@ -387,35 +335,23 @@ var Store = GObject.registerClass({
      * @param {ByteArray} contents - An image ByteArray
      * @return {string|undefined} File path or %undefined on failure
      */
-    storeAvatar(contents) {
-        return new Promise((resolve, reject) => {
-            const md5 = GLib.compute_checksum_for_data(
-                GLib.ChecksumType.MD5,
-                contents
-            );
-            const file = this._cacheDir.get_child(`${md5}`);
+    async storeAvatar(contents) {
+        const md5 = GLib.compute_checksum_for_data(GLib.ChecksumType.MD5,
+            contents);
+        const file = this._cacheDir.get_child(`${md5}`);
 
-            if (file.query_exists(null)) {
-                resolve(file.get_path());
-            } else {
-                file.replace_contents_bytes_async(
+        if (!file.query_exists(null)) {
+            try {
+                await file.replace_contents_bytes_async(
                     new GLib.Bytes(contents),
-                    null,
-                    false,
-                    Gio.FileCreateFlags.REPLACE_DESTINATION,
-                    null,
-                    (file, res) => {
-                        try {
-                            file.replace_contents_finish(res);
-                            resolve(file.get_path());
-                        } catch (e) {
-                            debug(e, 'Storing avatar');
-                            resolve(undefined);
-                        }
-                    }
-                );
+                    null, false, Gio.FileCreateFlags.REPLACE_DESTINATION, null);
+            } catch (e) {
+                debug(e, 'Storing avatar');
+                return undefined;
             }
-        });
+        }
+
+        return file.get_path();
     }
 
     /**
@@ -623,17 +559,8 @@ var Store = GObject.registerClass({
      */
     async load() {
         try {
-            this._cacheData = await new Promise((resolve, reject) => {
-                this._cacheFile.load_contents_async(null, (file, res) => {
-                    try {
-                        const contents = file.load_contents_finish(res)[1];
-
-                        resolve(JSON.parse(ByteArray.toString(contents)));
-                    } catch (e) {
-                        reject(e);
-                    }
-                });
-            });
+            const [contents] = await this._cacheFile.load_contents_async(null);
+            this._cacheData = JSON.parse(ByteArray.toString(contents));
         } catch (e) {
             debug(e);
         } finally {
@@ -657,22 +584,9 @@ var Store = GObject.registerClass({
         try {
             this.__cache_lock = true;
 
-            await new Promise((resolve, reject) => {
-                this._cacheFile.replace_contents_bytes_async(
-                    new GLib.Bytes(JSON.stringify(this._cacheData, null, 2)),
-                    null,
-                    false,
-                    Gio.FileCreateFlags.REPLACE_DESTINATION,
-                    null,
-                    (file, res) => {
-                        try {
-                            resolve(file.replace_contents_finish(res));
-                        } catch (e) {
-                            reject(e);
-                        }
-                    }
-                );
-            });
+            const contents = new GLib.Bytes(JSON.stringify(this._cacheData, null, 2));
+            await this._cacheFile.replace_contents_bytes_async(contents, null,
+                false, Gio.FileCreateFlags.REPLACE_DESTINATION, null);
         } catch (e) {
             debug(e);
         } finally {

--- a/src/service/components/mpris.js
+++ b/src/service/components/mpris.js
@@ -583,30 +583,6 @@ const PlayerProxy = GObject.registerClass({
         }
     }
 
-    initPromise() {
-        const application = new Promise((resolve, reject) => {
-            this._application.init_async(0, this._cancellable, (proxy, res) => {
-                try {
-                    resolve(proxy.init_finish(res));
-                } catch (e) {
-                    reject(e);
-                }
-            });
-        });
-
-        const player = new Promise((resolve, reject) => {
-            this._player.init_async(0, this._cancellable, (proxy, res) => {
-                try {
-                    resolve(proxy.init_finish(res));
-                } catch (e) {
-                    reject(e);
-                }
-            });
-        });
-
-        return Promise.all([application, player]);
-    }
-
     /*
      * The org.mpris.MediaPlayer2 Interface
      */
@@ -856,27 +832,18 @@ var Manager = GObject.registerClass({
 
     async _loadPlayers() {
         try {
-            const names = await new Promise((resolve, reject) => {
-                this._connection.call(
-                    'org.freedesktop.DBus',
-                    '/org/freedesktop/DBus',
-                    'org.freedesktop.DBus',
-                    'ListNames',
-                    null,
-                    null,
-                    Gio.DBusCallFlags.NONE,
-                    -1,
-                    this._cancellable,
-                    (connection, res) => {
-                        try {
-                            res = connection.call_finish(res);
-                            resolve(res.deepUnpack()[0]);
-                        } catch (e) {
-                            reject(e);
-                        }
-                    }
-                );
-            });
+            const reply = await this._connection.call(
+                'org.freedesktop.DBus',
+                '/org/freedesktop/DBus',
+                'org.freedesktop.DBus',
+                'ListNames',
+                null,
+                null,
+                Gio.DBusCallFlags.NONE,
+                -1,
+                this._cancellable);
+
+            const names = reply.deepUnpack()[0];
 
             for (let i = 0, len = names.length; i < len; i++) {
                 const name = names[i];
@@ -909,7 +876,12 @@ var Manager = GObject.registerClass({
         try {
             if (!this._players.has(name)) {
                 const player = new PlayerProxy(name);
-                await player.initPromise();
+                await Promise.all([
+                    player._application.init_async(GLib.PRIORITY_DEFAULT,
+                        this._cancellable),
+                    player._player.init_async(GLib.PRIORITY_DEFAULT,
+                        this._cancellable),
+                ]);
 
                 player.connect('notify',
                     (player) => this.emit('player-changed', player));

--- a/src/service/components/notification.js
+++ b/src/service/components/notification.js
@@ -111,52 +111,34 @@ const Listener = GObject.registerClass({
         }
     }
 
-    _listNames() {
-        return new Promise((resolve, reject) => {
-            this._session.call(
-                'org.freedesktop.DBus',
-                '/org/freedesktop/DBus',
-                'org.freedesktop.DBus',
-                'ListNames',
-                null,
-                null,
-                Gio.DBusCallFlags.NONE,
-                -1,
-                null,
-                (connection, res) => {
-                    try {
-                        res = connection.call_finish(res);
-                        resolve(res.deepUnpack()[0]);
-                    } catch (e) {
-                        reject(e);
-                    }
-                }
-            );
-        });
+    async _listNames() {
+        const reply = await this._session.call(
+            'org.freedesktop.DBus',
+            '/org/freedesktop/DBus',
+            'org.freedesktop.DBus',
+            'ListNames',
+            null,
+            null,
+            Gio.DBusCallFlags.NONE,
+            -1,
+            null);
+
+        return reply.deepUnpack()[0];
     }
 
-    _getNameOwner(name) {
-        return new Promise((resolve, reject) => {
-            this._session.call(
-                'org.freedesktop.DBus',
-                '/org/freedesktop/DBus',
-                'org.freedesktop.DBus',
-                'GetNameOwner',
-                new GLib.Variant('(s)', [name]),
-                null,
-                Gio.DBusCallFlags.NONE,
-                -1,
-                null,
-                (connection, res) => {
-                    try {
-                        res = connection.call_finish(res);
-                        resolve(res.deepUnpack()[0]);
-                    } catch (e) {
-                        reject(e);
-                    }
-                }
-            );
-        });
+    async _getNameOwner(name) {
+        const reply = await this._session.call(
+            'org.freedesktop.DBus',
+            '/org/freedesktop/DBus',
+            'org.freedesktop.DBus',
+            'GetNameOwner',
+            new GLib.Variant('(s)', [name]),
+            null,
+            Gio.DBusCallFlags.NONE,
+            -1,
+            null);
+
+        return reply.deepUnpack()[0];
     }
 
     /**
@@ -284,68 +266,49 @@ const Listener = GObject.registerClass({
      * @return {Promise} A promise for the operation
      */
     _monitorConnection() {
-        return new Promise((resolve, reject) => {
-            // libnotify Interface
-            this._fdoNotifications = new GjsPrivate.DBusImplementation({
-                g_interface_info: FDO_IFACE,
-            });
-            this._fdoMethodCallId = this._fdoNotifications.connect(
-                'handle-method-call',
-                this._onHandleMethodCall.bind(this)
-            );
-            this._fdoNotifications.export(
-                this._monitor,
-                '/org/freedesktop/Notifications'
-            );
-
-            this._fdoNameOwnerChangedId = this._session.signal_subscribe(
-                'org.freedesktop.DBus',
-                'org.freedesktop.DBus',
-                'NameOwnerChanged',
-                '/org/freedesktop/DBus',
-                'org.freedesktop.Notifications',
-                Gio.DBusSignalFlags.MATCH_ARG0_NAMESPACE,
-                this._onFdoNameOwnerChanged.bind(this)
-            );
-
-            // GNotification Interface
-            this._gtkNotifications = new GjsPrivate.DBusImplementation({
-                g_interface_info: GTK_IFACE,
-            });
-            this._gtkMethodCallId = this._gtkNotifications.connect(
-                'handle-method-call',
-                this._onHandleMethodCall.bind(this)
-            );
-            this._gtkNotifications.export(
-                this._monitor,
-                '/org/gtk/Notifications'
-            );
-
-            // Become a monitor for Fdo & Gtk notifications
-            this._monitor.call(
-                'org.freedesktop.DBus',
-                '/org/freedesktop/DBus',
-                'org.freedesktop.DBus.Monitoring',
-                'BecomeMonitor',
-                new GLib.Variant('(asu)', [[FDO_MATCH, GTK_MATCH], 0]),
-                null,
-                Gio.DBusCallFlags.NONE,
-                -1,
-                null,
-                (connection, res) => {
-                    try {
-                        resolve(connection.call_finish(res));
-                    } catch (e) {
-                        reject(e);
-                    }
-                }
-            );
+        // libnotify Interface
+        this._fdoNotifications = new GjsPrivate.DBusImplementation({
+            g_interface_info: FDO_IFACE,
         });
+        this._fdoMethodCallId = this._fdoNotifications.connect(
+            'handle-method-call', this._onHandleMethodCall.bind(this));
+        this._fdoNotifications.export(this._monitor,
+            '/org/freedesktop/Notifications');
+
+        this._fdoNameOwnerChangedId = this._session.signal_subscribe(
+            'org.freedesktop.DBus',
+            'org.freedesktop.DBus',
+            'NameOwnerChanged',
+            '/org/freedesktop/DBus',
+            'org.freedesktop.Notifications',
+            Gio.DBusSignalFlags.MATCH_ARG0_NAMESPACE,
+            this._onFdoNameOwnerChanged.bind(this)
+        );
+
+        // GNotification Interface
+        this._gtkNotifications = new GjsPrivate.DBusImplementation({
+            g_interface_info: GTK_IFACE,
+        });
+        this._gtkMethodCallId = this._gtkNotifications.connect(
+            'handle-method-call', this._onHandleMethodCall.bind(this));
+        this._gtkNotifications.export(this._monitor, '/org/gtk/Notifications');
+
+        // Become a monitor for Fdo & Gtk notifications
+        return this._monitor.call(
+            'org.freedesktop.DBus',
+            '/org/freedesktop/DBus',
+            'org.freedesktop.DBus.Monitoring',
+            'BecomeMonitor',
+            new GLib.Variant('(asu)', [[FDO_MATCH, GTK_MATCH], 0]),
+            null,
+            Gio.DBusCallFlags.NONE,
+            -1,
+            null);
     }
 
     async _init_async() {
         try {
-            this._session = await DBus.getConnection();
+            this._session = Gio.DBus.session;
             this._monitor = await DBus.newConnection();
             await this._monitorConnection();
         } catch (e) {

--- a/src/service/components/sound.js
+++ b/src/service/components/sound.js
@@ -50,17 +50,8 @@ var Player = class Player {
     }
 
     _canberraPlaySound(name, cancellable) {
-        return new Promise((resolve, reject) => {
-            const proc = this._canberra.spawnv(['canberra-gtk-play', '-i', name]);
-
-            proc.wait_check_async(cancellable, (proc, res) => {
-                try {
-                    resolve(proc.wait_check_finish(res));
-                } catch (e) {
-                    reject(e);
-                }
-            });
-        });
+        const proc = this._canberra.spawnv(['canberra-gtk-play', '-i', name]);
+        return proc.wait_check_async(cancellable);
     }
 
     async _canberraLoopSound(name, cancellable) {

--- a/src/service/components/upower.js
+++ b/src/service/components/upower.js
@@ -103,24 +103,11 @@ var Battery = GObject.registerClass({
                 g_flags: Gio.DBusProxyFlags.DO_NOT_AUTO_START,
             });
 
-            await new Promise((resolve, reject) => {
-                this._proxy.init_async(
-                    GLib.PRIORITY_DEFAULT,
-                    this._cancellable,
-                    (proxy, res) => {
-                        try {
-                            resolve(proxy.init_finish(res));
-                        } catch (e) {
-                            reject(e);
-                        }
-                    }
-                );
-            });
+            await this._proxy.init_async(GLib.PRIORITY_DEFAULT,
+                this._cancellable);
 
             this._propertiesChangedId = this._proxy.connect(
-                'g-properties-changed',
-                this._onPropertiesChanged.bind(this)
-            );
+                'g-properties-changed', this._onPropertiesChanged.bind(this));
 
             this._initProperties(this._proxy);
         } catch (e) {

--- a/src/service/plugin.js
+++ b/src/service/plugin.js
@@ -185,23 +185,13 @@ var Plugin = GObject.registerClass({
             GLib.mkdir_with_parents(cachedir, 448);
 
             this._cacheFile = Gio.File.new_for_path(
-                GLib.build_filenamev([cachedir, `${this.name}.json`])
-            );
+                GLib.build_filenamev([cachedir, `${this.name}.json`]));
 
             // Read the cache from disk
-            await new Promise((resolve, reject) => {
-                this._cacheFile.load_contents_async(null, (file, res) => {
-                    try {
-                        const contents = file.load_contents_finish(res)[1];
-                        const cache = JSON.parse(ByteArray.toString(contents));
-                        Object.assign(this, cache);
-
-                        resolve();
-                    } catch (e) {
-                        reject(e);
-                    }
-                });
-            });
+            const [contents] = await this._cacheFile.load_contents_async(
+                this.cancellable);
+            const cache = JSON.parse(ByteArray.toString(contents));
+            Object.assign(this, cache);
         } catch (e) {
             debug(e.message, `${this.device.name}: ${this.name}`);
         } finally {

--- a/src/service/plugins/notification.js
+++ b/src/service/plugins/notification.js
@@ -357,32 +357,9 @@ var Plugin = GObject.registerClass({
      * @param {Gio.File} file - A file object for the icon
      */
     async _uploadFileIcon(packet, file) {
-        const read = new Promise((resolve, reject) => {
-            file.read_async(GLib.PRIORITY_DEFAULT, null, (file, res) => {
-                try {
-                    resolve(file.read_finish(res));
-                } catch (e) {
-                    reject(e);
-                }
-            });
-        });
-
-        const query = new Promise((resolve, reject) => {
-            file.query_info_async(
-                'standard::size',
-                Gio.FileQueryInfoFlags.NONE,
-                GLib.PRIORITY_DEFAULT,
-                null,
-                (file, res) => {
-                    try {
-                        resolve(file.query_info_finish(res));
-                    } catch (e) {
-                        reject(e);
-                    }
-                }
-            );
-        });
-
+        const read = file.read_async(GLib.PRIORITY_DEFAULT, null);
+        const query = file.query_info_async('standard::size',
+            Gio.FileQueryInfoFlags.NONE, GLib.PRIORITY_DEFAULT, null);
         const [stream, info] = await Promise.all([read, query]);
 
         this._uploadIconStream(packet, stream, info.get_size());

--- a/src/service/plugins/photo.js
+++ b/src/service/plugins/photo.js
@@ -161,27 +161,18 @@ var Plugin = GObject.registerClass({
      * @return {Promise<string>} A file path
      */
     _takePhoto(packet) {
-        return new Promise((resolve, reject) => {
-            const time = GLib.DateTime.new_now_local().format('%T');
-            const path = GLib.build_filenamev([GLib.get_tmp_dir(), `${time}.jpg`]);
-            const proc = this._launcher.spawnv([
-                Config.FFMPEG_PATH,
-                '-f', 'video4linux2',
-                '-ss', '0:0:2',
-                '-i', '/dev/video0',
-                '-frames', '1',
-                path,
-            ]);
+        const time = GLib.DateTime.new_now_local().format('%T');
+        const path = GLib.build_filenamev([GLib.get_tmp_dir(), `${time}.jpg`]);
+        const proc = this._launcher.spawnv([
+            Config.FFMPEG_PATH,
+            '-f', 'video4linux2',
+            '-ss', '0:0:2',
+            '-i', '/dev/video0',
+            '-frames', '1',
+            path,
+        ]);
 
-            proc.wait_check_async(null, (proc, res) => {
-                try {
-                    proc.wait_check_finish(res);
-                    resolve(path);
-                } catch (e) {
-                    reject(e);
-                }
-            });
-        });
+        return proc.wait_check_async(null);
     }
 
     /**

--- a/src/service/plugins/sftp.js
+++ b/src/service/plugins/sftp.js
@@ -154,37 +154,14 @@ var Plugin = GObject.registerClass({
     async _listDirectories(mount) {
         const file = mount.get_root();
 
-        const iter = await new Promise((resolve, reject) => {
-            file.enumerate_children_async(
-                Gio.FILE_ATTRIBUTE_STANDARD_NAME,
-                Gio.FileQueryInfoFlags.NOFOLLOW_SYMLINKS,
-                GLib.PRIORITY_DEFAULT,
-                this.cancellable,
-                (file, res) => {
-                    try {
-                        resolve(file.enumerate_children_finish(res));
-                    } catch (e) {
-                        reject(e);
-                    }
-                }
-            );
-        });
+        const iter = await file.enumerate_children_async(
+            Gio.FILE_ATTRIBUTE_STANDARD_NAME,
+            Gio.FileQueryInfoFlags.NOFOLLOW_SYMLINKS,
+            GLib.PRIORITY_DEFAULT,
+            this.cancellable);
 
-        const infos = await new Promise((resolve, reject) => {
-            iter.next_files_async(
-                MAX_MOUNT_DIRS,
-                GLib.PRIORITY_DEFAULT,
-                this.cancellable,
-                (iter, res) => {
-                    try {
-                        resolve(iter.next_files_finish(res));
-                    } catch (e) {
-                        reject(e);
-                    }
-                }
-            );
-        });
-
+        const infos = await iter.next_files_async(MAX_MOUNT_DIRS,
+            GLib.PRIORITY_DEFAULT, this.cancellable);
         iter.close_async(GLib.PRIORITY_DEFAULT, null, null);
 
         const directories = {};
@@ -251,26 +228,17 @@ var Plugin = GObject.registerClass({
             const uri = `sftp://${host}:${packet.body.port}/`;
             const file = Gio.File.new_for_uri(uri);
 
-            await new Promise((resolve, reject) => {
-                file.mount_enclosing_volume(0, op, null, (file, res) => {
-                    try {
-                        resolve(file.mount_enclosing_volume_finish(res));
-                    } catch (e) {
-                        // Special case when the GMount didn't unmount properly
-                        // but is still on the same port and can be reused.
-                        if (e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.ALREADY_MOUNTED)) {
-                            resolve(true);
-
-                        // There's a good chance this is a host key verification
-                        // error; regardless we'll remove the key for security.
-                        } else {
-                            this._removeHostKey(host);
-                            reject(e);
-                        }
-                    }
-                });
-            });
+            await file.mount_enclosing_volume(GLib.PRIORITY_DEFAULT, op,
+                this.cancellable);
         } catch (e) {
+            // Special case when the GMount didn't unmount properly but is still
+            // on the same port and can be reused.
+            if (e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.ALREADY_MOUNTED))
+                return;
+
+            // There's a good chance this is a host key verification error;
+            // regardless we'll remove the key for security.
+            this._removeHostKey(this.device.channel.host);
             logError(e, this.device.name);
         } finally {
             this._mounting = false;
@@ -283,26 +251,17 @@ var Plugin = GObject.registerClass({
      *
      * @return {Promise} A promise for the operation
      */
-    _addPrivateKey() {
+    async _addPrivateKey() {
         const ssh_add = this._launcher.spawnv([
             Config.SSHADD_PATH,
             GLib.build_filenamev([Config.CONFIGDIR, 'private.pem']),
         ]);
 
-        return new Promise((resolve, reject) => {
-            ssh_add.communicate_utf8_async(null, null, (proc, res) => {
-                try {
-                    const result = proc.communicate_utf8_finish(res)[1].trim();
+        const [stdout] = await ssh_add.communicate_utf8_async(null,
+            this.cancellable);
 
-                    if (proc.get_exit_status() !== 0)
-                        debug(result, this.device.name);
-
-                    resolve();
-                } catch (e) {
-                    reject(e);
-                }
-            });
-        });
+        if (ssh_add.get_exit_status() !== 0)
+            debug(stdout.trim(), this.device.name);
     }
 
     /**
@@ -320,25 +279,17 @@ var Plugin = GObject.registerClass({
                     `[${host}]:${port}`,
                 ]);
 
-                await new Promise((resolve, reject) => {
-                    ssh_keygen.communicate_utf8_async(null, null, (proc, res) => {
-                        try {
-                            const stdout = proc.communicate_utf8_finish(res)[1];
-                            const status = proc.get_exit_status();
+                const [stdout] = await ssh_keygen.communicate_utf8_async(null,
+                    this.cancellable);
 
-                            if (status !== 0) {
-                                throw new Gio.IOErrorEnum({
-                                    code: Gio.io_error_from_errno(status),
-                                    message: `${GLib.strerror(status)}\n${stdout}`.trim(),
-                                });
-                            }
+                const status = ssh_keygen.get_exit_status();
 
-                            resolve();
-                        } catch (e) {
-                            reject(e);
-                        }
+                if (status !== 0) {
+                    throw new Gio.IOErrorEnum({
+                        code: Gio.io_error_from_errno(status),
+                        message: `${GLib.strerror(status)}\n${stdout}`.trim(),
                     });
-                });
+                }
             } catch (e) {
                 logError(e, this.device.name);
             }
@@ -464,49 +415,27 @@ var Plugin = GObject.registerClass({
 
             const link_target = mount.get_root().get_path();
             const link = Gio.File.new_for_path(
-                `${by_name_dir.get_path()}/${safe_device_name}`
-            );
+                `${by_name_dir.get_path()}/${safe_device_name}`);
 
             // Check for and remove any existing stale link
             try {
-                const link_stat = await new Promise((resolve, reject) => {
-                    link.query_info_async(
-                        'standard::symlink-target',
-                        Gio.FileQueryInfoFlags.NOFOLLOW_SYMLINKS,
-                        GLib.PRIORITY_DEFAULT,
-                        null,
-                        (link, res) => {
-                            try {
-                                resolve(link.query_info_finish(res));
-                            } catch (e) {
-                                reject(e);
-                            }
-                        }
-                    );
-                });
+                const link_stat = await link.query_info_async(
+                    'standard::symlink-target',
+                    Gio.FileQueryInfoFlags.NOFOLLOW_SYMLINKS,
+                    GLib.PRIORITY_DEFAULT,
+                    this.cancellable);
 
                 if (link_stat.get_symlink_target() === link_target)
                     return;
 
-                await new Promise((resolve, reject) => {
-                    link.delete_async(
-                        GLib.PRIORITY_DEFAULT,
-                        null,
-                        (link, res) => {
-                            try {
-                                resolve(link.delete_finish(res));
-                            } catch (e) {
-                                reject(e);
-                            }
-                        }
-                    );
-                });
+                await link.delete_async(GLib.PRIORITY_DEFAULT,
+                    this.cancellable);
             } catch (e) {
                 if (!e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.NOT_FOUND))
                     throw e;
             }
 
-            link.make_symbolic_link(link_target, null);
+            link.make_symbolic_link(link_target, this.cancellable);
         } catch (e) {
             debug(e, this.device.name);
         }
@@ -538,20 +467,10 @@ var Plugin = GObject.registerClass({
             this._removeSubmenu();
             this._mounting = false;
 
-            await new Promise((resolve, reject) => {
-                this.gmount.unmount_with_operation(
-                    Gio.MountUnmountFlags.FORCE,
-                    new Gio.MountOperation(),
-                    null,
-                    (mount, res) => {
-                        try {
-                            resolve(mount.unmount_with_operation_finish(res));
-                        } catch (e) {
-                            reject(e);
-                        }
-                    }
-                );
-            });
+            await this.gmount.unmount_with_operation(
+                Gio.MountUnmountFlags.FORCE,
+                new Gio.MountOperation(),
+                this.cancellable);
         } catch (e) {
             debug(e, this.device.name);
         }

--- a/src/service/utils/dbus.js
+++ b/src/service/utils/dbus.js
@@ -234,26 +234,6 @@ var Interface = GObject.registerClass({
     }
 });
 
-
-/**
- * Get the DBus connection on @busType
- *
- * @param {Gio.BusType} [busType] - a Gio.BusType constant
- * @param {Gio.Cancellable} [cancellable] - an optional Gio.Cancellable
- * @return {Promise<Gio.DBusConnection>} A DBus connection
- */
-function getConnection(busType = Gio.BusType.SESSION, cancellable = null) {
-    return new Promise((resolve, reject) => {
-        Gio.bus_get(busType, cancellable, (connection, res) => {
-            try {
-                resolve(Gio.bus_get_finish(res));
-            } catch (e) {
-                reject(e);
-            }
-        });
-    });
-}
-
 /**
  * Get a new, dedicated DBus connection on @busType
  *


### PR DESCRIPTION
This tech-preview isn't going anywhere, and in fact will become a part
of GJS soon. Port to the more modern async-await patterns throughout
the service.

Depends on #1655