### PR TITLE
Hide Waydroid devices from the quick settings panel

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -132,9 +132,10 @@ const ServiceToggle = GObject.registerClass({
     }
 
     _sync() {
-        const available = this.service.devices.filter(device => {
+        const availableBeforeFiltering = this.service.devices.filter(device => {
             return (device.connected && device.paired);
         });
+        const available = availableBeforeFiltering.filter(device => !(device.name && device.name.toLowerCase().includes('waydroid')));
         const panelMode = this.settings.get_boolean('show-indicators');
 
         // Hide status indicator if in Panel mode or no devices are available


### PR DESCRIPTION
Until waydroid resolves this https://github.com/waydroid/waydroid/issues/211, GSConnect is a really good and seamless alternative to get the notifications to show up natively,
but the Waydroid device showing up in quick settings looks ugly and sort of exposes the "implementation detail" of this workaround,
skipping the Waydroid device in quick settings makes things look neat.
The Waydroid device will still show up in the settings menu so no issues with configuring this.
I know this is "hacky", raising this mostly to get views from GSConnect team on this and also to help anyone else who might want to achieve the same thing as this.