### PR TITLE
fix: remove exception for TLSv1.0

### DIFF
--- a/src/service/daemon.js
+++ b/src/service/daemon.js
@@ -6,10 +6,6 @@
 
 'use strict';
 
-// Allow TLSv1.0 certificates
-// See https://github.com/GSConnect/gnome-shell-extension-gsconnect/issues/930
-imports.gi.GLib.setenv('G_TLS_GNUTLS_PRIORITY', 'NORMAL:%COMPAT:+VERS-TLS1.0', true);
-
 imports.gi.versions.Gdk = '3.0';
 imports.gi.versions.GdkPixbuf = '2.0';
 imports.gi.versions.Gio = '2.0';


### PR DESCRIPTION
This has been removed from upstream for awhile, and seems to be purturbing some folks.

closes #1606
closes #1638