### PR TITLE
shell/utils: Fix Gio bitfield value

### DIFF
--- a/src/shell/utils.js
+++ b/src/shell/utils.js
@@ -140,7 +140,7 @@ function _setExecutable(filepath) {
         const file = Gio.File.new_for_path(filepath);
         const finfo = file.query_info(
             `${Gio.FILE_ATTRIBUTE_STANDARD_TYPE},${Gio.FILE_ATTRIBUTE_UNIX_MODE}`,
-            Gio.FileQueryInfoFlags.NO_FOLLOW_SYMLINKS,
+            Gio.FileQueryInfoFlags.NOFOLLOW_SYMLINKS,
             null);
 
         if (!finfo.has_attribute(Gio.FILE_ATTRIBUTE_UNIX_MODE))
@@ -155,7 +155,7 @@ function _setExecutable(filepath) {
         return file.set_attribute_uint32(
             Gio.FILE_ATTRIBUTE_UNIX_MODE,
             new_mode,
-            Gio.FileQueryInfoFlags.NO_FOLLOW_SYMLINKS,
+            Gio.FileQueryInfoFlags.NOFOLLOW_SYMLINKS,
             null);
     } catch (e) {
         logError(e, 'GSConnect');


### PR DESCRIPTION
I got the name of a bitfield member wrong, when using `Gio.File.query_info`: the `FileQueryInfoFlags` member is named `NOFOLLOW_SYMLINKS`, not `NO_FOLLOW_SYMLINKS`.

I'm not 100% sure this makes any difference. (Most likely, it just means the calls are made with flags of `0` (`NONE`) instead. Which is fine, since the files being examined _aren't_ symlinks.) But, worst case scenario is that the calls fail and the permissions on the target files aren't fixed. So, better to use the correct name.