### PR TITLE
Quick fixes for GNOME 45 compatibility

### DIFF
--- a/src/service/components/input.js
+++ b/src/service/components/input.js
@@ -381,29 +381,6 @@ class Controller {
         return reply.deepUnpack()[0];
     }
 
-    async _createScreenCastSession(sessionId) {
-        if (this.connection === null)
-            throw new Error('No DBus connection');
-
-        const options = new GLib.Variant('(a{sv})', [{
-            'disable-animations': GLib.Variant.new_boolean(false),
-            'remote-desktop-session-id': GLib.Variant.new_string(sessionId),
-        }]);
-
-        const reply = await this.connection.call(
-            'org.gnome.Mutter.ScreenCast',
-            '/org/gnome/Mutter/ScreenCast',
-            'org.gnome.Mutter.ScreenCast',
-            'CreateSession',
-            options,
-            null,
-            Gio.DBusCallFlags.NONE,
-            -1,
-            null);
-
-        return reply.deepUnpack()[0];
-    }
-
     async _ensureAdapter() {
         try {
             // Update the timestamp of the last event
@@ -437,8 +414,6 @@ class Controller {
 
                 this._session = new RemoteSession(objectPath);
                 await this._session.start();
-
-                await this._createScreenCastSession(this._session.session_id);
 
                 // Watch for the session ending
                 this._sessionClosedId = this._session.connect(

--- a/src/service/utils/setup.js
+++ b/src/service/utils/setup.js
@@ -20,7 +20,7 @@ try {
     Gio._promisify(EBook.BookClient.prototype, 'get_view');
     Gio._promisify(EBook.BookClient.prototype, 'get_contacts');
     Gio._promisify(EDataServer.SourceRegistry, 'new');
-} catch(e) {
+} catch (e) {
     // Silence import errors
 }
 

--- a/src/service/utils/setup.js
+++ b/src/service/utils/setup.js
@@ -20,7 +20,7 @@ try {
     Gio._promisify(EBook.BookClient.prototype, 'get_view');
     Gio._promisify(EBook.BookClient.prototype, 'get_contacts');
     Gio._promisify(EDataServer.SourceRegistry, 'new');
-} finally {
+} catch(e) {
     // Silence import errors
 }
 


### PR DESCRIPTION
I couldn't get the code in https://github.com/GSConnect/gnome-shell-extension-gsconnect/pull/1683 to a state where the main UI would open, with the most blocking part being Gvc, which seems to have been originally difficult as well https://stackoverflow.com/questions/46674935/is-it-possible-to-import-the-gvc-typelib-outside-of-the-gnome-shell-environment

With this small change at least some things work and we could maybe put out a release, though for example remote input from phone to computer doesn't yet.