### PR TITLE
Fixed Import Error

### DIFF
--- a/src/service/utils/setup.js
+++ b/src/service/utils/setup.js
@@ -20,7 +20,7 @@ try {
     Gio._promisify(EBook.BookClient.prototype, 'get_view');
     Gio._promisify(EBook.BookClient.prototype, 'get_contacts');
     Gio._promisify(EDataServer.SourceRegistry, 'new');
-} catch{
+} catch {
     // Silence import errors
 } finally {
     // Silence import errors

--- a/src/service/utils/setup.js
+++ b/src/service/utils/setup.js
@@ -20,6 +20,8 @@ try {
     Gio._promisify(EBook.BookClient.prototype, 'get_view');
     Gio._promisify(EBook.BookClient.prototype, 'get_contacts');
     Gio._promisify(EDataServer.SourceRegistry, 'new');
+} catch{
+    // Silence import errors
 } finally {
     // Silence import errors
 }


### PR DESCRIPTION
Fix an error where the service isn't starting. The reason for this was that the try...finally block wasn't always catching the exception. An essential catch has been added. Now the service is running and everything works fine.