### PR TITLE
fix: Use imports to detect GNOME environment

### DIFF
--- a/src/service/utils/setup.js
+++ b/src/service/utils/setup.js
@@ -105,7 +105,7 @@ for (const path of [Config.CACHEDIR, Config.CONFIGDIR, Config.RUNTIMEDIR])
  */
 globalThis.HAVE_REMOTEINPUT = GLib.getenv('GDMSESSION') !== 'ubuntu-wayland';
 globalThis.HAVE_WAYLAND = GLib.getenv('XDG_SESSION_TYPE') === 'wayland';
-globalThis.HAVE_GNOME = GLib.getenv('GNOME_SETUP_DISPLAY') !== null;
+globalThis.HAVE_GNOME = GLib.getenv('GSCONNECT_MODE')?.toLowerCase() !== 'cli' && (GLib.getenv('GNOME_SETUP_DISPLAY') !== null || GLib.getenv('XDG_CURRENT_DESKTOP')?.toUpperCase() === 'GNOME' || GLib.getenv('XDG_SESSION_DESKTOP')?.toLowerCase() === 'gnome');
 
 
 /**


### PR DESCRIPTION
The environment variable GNOME_SETUP_DISPLAY is not reliably set since GNOME 45.
We revert to use `imports.ui` for detecting method of GNOME environment. Fix #1706