### PR TITLE
fix: $XDG_CURRENT_DESKTOP is a colon-split string

### DIFF
--- a/src/service/utils/setup.js
+++ b/src/service/utils/setup.js
@@ -105,7 +105,7 @@ for (const path of [Config.CACHEDIR, Config.CONFIGDIR, Config.RUNTIMEDIR])
  */
 globalThis.HAVE_REMOTEINPUT = GLib.getenv('GDMSESSION') !== 'ubuntu-wayland';
 globalThis.HAVE_WAYLAND = GLib.getenv('XDG_SESSION_TYPE') === 'wayland';
-globalThis.HAVE_GNOME = GLib.getenv('GSCONNECT_MODE')?.toLowerCase() !== 'cli' && (GLib.getenv('GNOME_SETUP_DISPLAY') !== null || GLib.getenv('XDG_CURRENT_DESKTOP')?.toUpperCase() === 'GNOME' || GLib.getenv('XDG_SESSION_DESKTOP')?.toLowerCase() === 'gnome');
+globalThis.HAVE_GNOME = GLib.getenv('GSCONNECT_MODE')?.toLowerCase() !== 'cli' && (GLib.getenv('GNOME_SETUP_DISPLAY') !== null || GLib.getenv('XDG_CURRENT_DESKTOP')?.toUpperCase()?.includes('GNOME') || GLib.getenv('XDG_SESSION_DESKTOP')?.toLowerCase() === 'gnome');
 
 
 /**


### PR DESCRIPTION
If $XDG_CURRENT_DESKTOP is set then it contains a colon-separated list of strings, as said in the refrence:
https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#recognized-keys

For example, this env variable could have value `ubuntu:GNOME`, as mentioned by @StephGbzh 