### PR TITLE
fix: re-enable remote input on Ubuntu w/Wayland

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -281,9 +281,7 @@
         "_": false,
         "_C": false,
         "_N": false,
-        "ngettext": false,
-
-        "HAVE_WAYLAND": false
+        "ngettext": false
     },
     "parserOptions": {
         "ecmaVersion": "latest"

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -283,8 +283,7 @@
         "_N": false,
         "ngettext": false,
 
-        "HAVE_WAYLAND": false,
-        "HAVE_REMOTEINPUT": false
+        "HAVE_WAYLAND": false
     },
     "parserOptions": {
         "ecmaVersion": "latest"

--- a/src/service/components/input.js
+++ b/src/service/components/input.js
@@ -276,8 +276,6 @@ class Controller {
      */
     _checkWayland() {
         if (HAVE_WAYLAND) {
-            // eslint-disable-next-line no-global-assign
-            HAVE_REMOTEINPUT = false;
             const service = Gio.Application.get_default();
 
             if (service === null)

--- a/src/service/core.js
+++ b/src/service/core.js
@@ -410,10 +410,6 @@ var ChannelService = GObject.registerClass({
         });
 
         for (const name in imports.service.plugins) {
-            // Exclude mousepad/presenter capability in unsupported sessions
-            if (!HAVE_REMOTEINPUT && ['mousepad', 'presenter'].includes(name))
-                continue;
-
             const meta = imports.service.plugins[name].Metadata;
 
             if (meta === undefined)

--- a/src/service/device.js
+++ b/src/service/device.js
@@ -298,10 +298,6 @@ var Device = GObject.registerClass({
         const supported = [];
 
         for (const name in imports.service.plugins) {
-            // Exclude mousepad/presenter plugins in unsupported sessions
-            if (!HAVE_REMOTEINPUT && ['mousepad', 'presenter'].includes(name))
-                continue;
-
             const meta = imports.service.plugins[name].Metadata;
 
             if (meta === undefined)

--- a/src/service/utils/setup.js
+++ b/src/service/utils/setup.js
@@ -99,11 +99,6 @@ for (const path of [Config.CACHEDIR, Config.CONFIGDIR, Config.RUNTIMEDIR])
     GLib.mkdir_with_parents(path, 0o755);
 
 
-/**
- * Check if we're in a Wayland session (mostly for input synthesis)
- * https://wiki.gnome.org/Accessibility/Wayland#Bugs.2FIssues_We_Must_Address
- */
-globalThis.HAVE_WAYLAND = GLib.getenv('XDG_SESSION_TYPE') === 'wayland';
 globalThis.HAVE_GNOME = GLib.getenv('GSCONNECT_MODE')?.toLowerCase() !== 'cli' && (GLib.getenv('GNOME_SETUP_DISPLAY') !== null || GLib.getenv('XDG_CURRENT_DESKTOP')?.toUpperCase()?.includes('GNOME') || GLib.getenv('XDG_SESSION_DESKTOP')?.toLowerCase() === 'gnome');
 
 

--- a/src/service/utils/setup.js
+++ b/src/service/utils/setup.js
@@ -103,7 +103,6 @@ for (const path of [Config.CACHEDIR, Config.CONFIGDIR, Config.RUNTIMEDIR])
  * Check if we're in a Wayland session (mostly for input synthesis)
  * https://wiki.gnome.org/Accessibility/Wayland#Bugs.2FIssues_We_Must_Address
  */
-globalThis.HAVE_REMOTEINPUT = GLib.getenv('GDMSESSION') !== 'ubuntu-wayland';
 globalThis.HAVE_WAYLAND = GLib.getenv('XDG_SESSION_TYPE') === 'wayland';
 globalThis.HAVE_GNOME = GLib.getenv('GSCONNECT_MODE')?.toLowerCase() !== 'cli' && (GLib.getenv('GNOME_SETUP_DISPLAY') !== null || GLib.getenv('XDG_CURRENT_DESKTOP')?.toUpperCase()?.includes('GNOME') || GLib.getenv('XDG_SESSION_DESKTOP')?.toLowerCase() === 'gnome');
 


### PR DESCRIPTION
Remote Input was [disabled](https://github.com/GSConnect/gnome-shell-extension-gsconnect/commit/5e98fcf79dad73ea57ee98ef2d7c88316abf370d) on Ubuntu sessions using Wayland a while back as Ubuntu and Debian disabled the `remote-desktop` flag ([1](https://github.com/GSConnect/gnome-shell-extension-gsconnect/issues/688#issuecomment-550476892), [2](https://github.com/GSConnect/gnome-shell-extension-gsconnect/issues/822#issuecomment-616723699)).

However, looking at the commits after the second comment, [they turned it back on](https://salsa.debian.org/gnome-team/mutter/-/commit/aefb8326692e0e44af18e9f21dbfdc8b9bb41081) for all Linux builds in early 2021 and haven't touched it since. I've tested Remote Input on Ubuntu 23.10 with this patch and everything seems to be working.