### PR TITLE
Add GNOME 46 to supported versions

### DIFF
--- a/data/metadata.json.in
+++ b/data/metadata.json.in
@@ -3,6 +3,6 @@
     "name": "GSConnect",
     "description": "GSConnect is a complete implementation of KDE Connect especially for GNOME Shell with Nautilus, Chrome and Firefox integration. It does not rely on the KDE Connect desktop application and will not work with it installed.\n\nKDE Connect allows devices to securely share content like notifications or files and other features like SMS messaging and remote control. The KDE Connect team has applications for Linux, BSD, Android, Sailfish, iOS, macOS and Windows.\n\nPlease report issues on Github!",
     "version": @PACKAGE_VERSION@,
-    "shell-version": [ "45" ],
+    "shell-version": [ "45", "46" ],
     "url": "@PACKAGE_URL@/wiki"
 }


### PR DESCRIPTION
Basic functionality works for me. I tried setting a keyboard shortcut and it did not work but I never used this feature in previous versions.

```
JS ERROR: Gio.DBusError: GDBus.Error:org.freedesktop.DBus.Error.AccessDenied:
GrabAccelerator is not allowed
checkAccelerator/action</<@/usr/share/gnome-shell/extensions/
 gsconnect@andyholmes.github.io/preferences/keybindings.js:230:42
 @/usr/share/gnome-shell/extensions/gsconnect@andyholmes.github.io/gsconnect-preferences:127:21
```

Here is an overview of changes in GNOME Shell 46 Beta: https://gjs.guide/extensions/upgrading/gnome-shell-46.html