### PR TITLE
PulseAudio: Protect against missing interfaces

### DIFF
--- a/src/service/components/pulseaudio.js
+++ b/src/service/components/pulseaudio.js
@@ -190,7 +190,7 @@ const Mixer = GObject.registerClass({
      */
     lowerVolume(duration = 1) {
         try {
-            if (this.output.volume > 0.15) {
+            if (this.output && this.output.volume > 0.15) {
                 this._previousVolume = Number(this.output.volume);
                 this.output.fade(0.15, duration);
             }
@@ -204,7 +204,7 @@ const Mixer = GObject.registerClass({
      */
     muteVolume() {
         try {
-            if (this.output.muted)
+            if (!this.output || this.output.muted)
                 return;
 
             this.output.muted = true;
@@ -219,7 +219,7 @@ const Mixer = GObject.registerClass({
      */
     muteMicrophone() {
         try {
-            if (this.input.muted)
+            if (!this.input || this.input.muted)
                 return;
 
             this.input.muted = true;
@@ -266,4 +266,3 @@ const Mixer = GObject.registerClass({
  * The service class for this component
  */
 var Component = Mixer;
-


### PR DESCRIPTION
Spotted this error in my user journal:

```text
Feb 19 09:32:31 teevey gjs[522096]: JS ERROR: TypeError: this.input is null
muteMicrophone@/home/ferd/.local/share/gnome-shell/extensions/gsconnect@andyholmes.github.io/service/components/pulseaudio.js:222:17
_setMediaState@/home/ferd/.local/share/gnome-shell/extensions/gsconnect@andyholmes.github.io/service/plugins/telephony.js:90:29
_notifyEvent@/home/ferd/.local/share/gnome-shell/extensions/gsconnect@andyholmes.github.io/service/plugins/telephony.js:207:18
_handleEvent@/home/ferd/.local/share/gnome-shell/extensions/gsconnect@andyholmes.github.io/service/plugins/telephony.js:151:18
handlePacket@/home/ferd/.local/share/gnome-shell/extensions/gsconnect@andyholmes.github.io/service/plugins/telephony.js:61:22
handlePacket@/home/ferd/.local/share/gnome-shell/extensions/gsconnect@andyholmes.github.io/service/device.js:441:25
_readLoop@/home/ferd/.local/share/gnome-shell/extensions/gsconnect@andyholmes.github.io/service/device.js:365:22
async*setChannel@/home/ferd/.local/share/gnome-shell/extensions/gsconnect@andyholmes.github.io/service/device.js:346:18
_onChannel@/home/ferd/.local/share/gnome-shell/extensions/gsconnect@andyholmes.github.io/service/manager.js:229:20
channel@/home/ferd/.local/share/gnome-shell/extensions/gsconnect@andyholmes.github.io/service/core.js:436:19
_onIncomingChannel@/home/ferd/.local/share/gnome-shell/extensions/gsconnect@andyholmes.github.io/service/backends/lan.js:244:18
async*@/home/ferd/.local/share/gnome-shell/extensions/gsconnect@andyholmes.github.io/service/daemon.js:720:17
```

Since `input()` and `output()` are both allowed to be/return `null`, and PulseAudio clients won't necessarily always have a default input or output configured, makes sense to test for a valid `this.input`or `this.output` object before trying to dereference it.

Didn't touch `restore()` since `this._microphoneMuted` being `true` _should_ imply the existence of a valid `this.input`, and if it's been invalidated in between the calls to `muteMicrophone()` and `restore()` that probably **is** an error worth logging.