### PR TITLE
CI: Add automatic labeling of merge-conflict PRs

### DIFF
--- a/.github/workflows/label-conflicts.yml
+++ b/.github/workflows/label-conflicts.yml
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: GSConnect Developers https://github.com/GSConnect
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+name: "Label merge conflicts"
+on:
+  # So that PRs touching the same files as the push are updated
+  push:
+  # So that the `dirtyLabel` is removed if conflicts are resolve
+  # We recommend `pull_request_target` so that github secrets are available.
+  # In `pull_request` we wouldn't be able to change labels of fork PRs
+  pull_request_target:
+    # GitHub documents "synchronize" as:
+    # A pull request's head branch was updated. For example, the head branch
+    # was updated from the base branch or new commits were pushed to the
+    # head branch.
+    types: [synchronize]
+
+jobs:
+  conflicts:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: check if PRs are mergeable
+        uses: eps1lon/actions-label-merge-conflict@v2.1.0
+        with:
+          dirtyLabel: "conflicts"
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"
+          commentOnDirty: "This pull request has conflicts, please resolve those so that the changes can be evaluated."
+          commentOnClean: "All conflicts have been resolved, thanks!"
+


### PR DESCRIPTION
This adds a tool I and others have found helpful (in particular) on projects that rely on contributions from external developers: A workflow based on the [eps1lon/action-label-merge-conflict](https://github.com/eps1lon/action-label-merge-conflict) GitHub Action that, well, does exactly what it says on the tin.

The workflow will run after any changes to PR target code, and if it discovers that those changes have placed the PR branch in conflict with the target, it will apply a nice, visible label, and add a comment requesting that the author resolve those conflicts and make the PR mergeable again. When it sees that they've done so, it will remove the label and post a comment thanking them for attending to the issue.

It makes PRs with conflicts visible right from the list of open PRs. Something that should really be a built-in GitHub feature (the same way CI passes and failures are flagged with green checkmarks or red X's), but somehow still is not.

All it requires by way of setup is the creation of the "conflicts" label (or whatever label name is configured), something I'll now go take care of in anticipation of this being turned on.