### PR TITLE
Gnome 46 support

### DIFF
--- a/data/metadata.json.in
+++ b/data/metadata.json.in
@@ -3,6 +3,6 @@
     "name": "GSConnect",
     "description": "GSConnect is a complete implementation of KDE Connect especially for GNOME Shell with Nautilus, Chrome and Firefox integration. It does not rely on the KDE Connect desktop application and will not work with it installed.\n\nKDE Connect allows devices to securely share content like notifications or files and other features like SMS messaging and remote control. The KDE Connect team has applications for Linux, BSD, Android, Sailfish, iOS, macOS and Windows.\n\nPlease report issues on Github!",
     "version": @PACKAGE_VERSION@,
-    "shell-version": [ "45", "46" ],
+    "shell-version": [ "46" ],
     "url": "@PACKAGE_URL@/wiki"
 }

--- a/src/shell/notification.js
+++ b/src/shell/notification.js
@@ -47,9 +47,8 @@ const NotificationBanner = GObject.registerClass({
     GTypeName: 'GSConnectNotificationBanner',
 }, class NotificationBanner extends Calendar.NotificationMessage {
 
-    _init(notification) {
-        super._init(notification);
-
+    constructor(notification) {
+        super(notification);
         if (notification.requestReplyId !== undefined)
             this._addReplyAction();
     }

--- a/src/shell/notification.js
+++ b/src/shell/notification.js
@@ -9,6 +9,7 @@ import St from 'gi://St';
 
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import * as MessageTray from 'resource:///org/gnome/shell/ui/messageTray.js';
+import * as Calendar from 'resource:///org/gnome/shell/ui/calendar.js';
 import * as NotificationDaemon from 'resource:///org/gnome/shell/ui/notificationDaemon.js';
 
 import {gettext as _} from 'resource:///org/gnome/shell/extensions/extension.js';
@@ -44,7 +45,7 @@ const GtkNotificationDaemon = Main.notificationDaemon._gtkNotificationDaemon.con
  */
 const NotificationBanner = GObject.registerClass({
     GTypeName: 'GSConnectNotificationBanner',
-}, class NotificationBanner extends MessageTray.NotificationBanner {
+}, class NotificationBanner extends Calendar.NotificationMessage {
 
     _init(notification) {
         super._init(notification);


### PR DESCRIPTION
In https://gitlab.gnome.org/GNOME/gnome-shell/-/commit/940b658071047fab8d1db18f301c59095b384f79, gnome maintainers decided to use `Calendar.NotificationMessage` for widget consistent.

closes #1764 