### PR TITLE
GNOME 46 fix - NotificationBanner

### DIFF
--- a/src/shell/notification.js
+++ b/src/shell/notification.js
@@ -367,8 +367,6 @@ export function unpatchGtkNotificationDaemon() {
 const _addNotification = NotificationDaemon.GtkNotificationDaemonAppSource.prototype.addNotification;
 
 export function patchGtkNotificationSources() {
-    const addNotification = Source.prototype.addNotification;
-
     // eslint-disable-next-line func-style
     const _withdrawGSConnectNotification = function (id, notification, reason) {
         if (reason !== MessageTray.NotificationDestroyedReason.DISMISSED)
@@ -410,7 +408,6 @@ export function patchGtkNotificationSources() {
         );
     };
 
-    NotificationDaemon.GtkNotificationDaemonAppSource.prototype.addNotification = addNotification;
     NotificationDaemon.GtkNotificationDaemonAppSource.prototype._withdrawGSConnectNotification = _withdrawGSConnectNotification;
 }
 

--- a/src/shell/notification.js
+++ b/src/shell/notification.js
@@ -214,7 +214,7 @@ const Source = GObject.registerClass({
 
         // Parse the id to determine if it's a repliable notification, device
         // notification or a regular local notification
-        let notificationId = notification.id;
+        const notificationId = notification.id;
         let idMatch, deviceId, requestReplyId, remoteId, localId;
 
         if ((idMatch = REPLY_REGEX.exec(notificationId))) {
@@ -283,7 +283,7 @@ const Source = GObject.registerClass({
             });
             this._notifications[localId] = cachedNotification;
         }
-        
+
         if (this.notifications.includes(cachedNotification)) {
             cachedNotification.acknowledged = false;
             this.emit('notification-request-banner', cachedNotification);

--- a/src/shell/notification.js
+++ b/src/shell/notification.js
@@ -230,14 +230,14 @@ const Source = GObject.registerClass({
         }
 
         // Fix themed icons
-        /* if (notificationParams.icon) {
-            let gicon = Gio.Icon.deserialize(notificationParams.icon);
+        if (notification.icon) {
+            let gicon = notification.icon;
 
             if (gicon instanceof Gio.ThemedIcon) {
                 gicon = getIcon(gicon.names[0]);
-                notificationParams.icon = gicon.serialize();
+                notification.icon = gicon.serialize();
             }
-        } */
+        }
 
         let cachedNotification = this._notifications[localId];
 


### PR DESCRIPTION
This pull request intends to fix the notification implementation for GNOME 46, with the new change from `MessageTray.NotificationBanner` to `Calendar.NotificationMessage`.

Tested on my computer of course, everything seems to be working pretty well :+1:

Closes #1768 
Closes #1770 