### PR TITLE
GNOME 46 notifications: Chase style change

### DIFF
--- a/src/shell/notification.js
+++ b/src/shell/notification.js
@@ -56,7 +56,7 @@ const NotificationBanner = GObject.registerClass({
     _addReplyAction() {
         if (!this._buttonBox) {
             this._buttonBox = new St.BoxLayout({
-                style_class: 'notification-actions',
+                style_class: 'notification-buttons-bin',
                 x_expand: true,
             });
             this.setActionArea(this._buttonBox);


### PR DESCRIPTION
One more minor GNOME 46 tweak.

The change to `Calendar.NotificationMessage` as the notification type [also renamed](https://gitlab.gnome.org/GNOME/gnome-shell/-/commit/d44adf3b781601c9a1b5d040e5c8ad2f864ab446) the `notification-actions` CSS class to `notification-buttons-bin`.