### PR TITLE
Use GioUnix for GNOME 46

### DIFF
--- a/installed-tests/fixtures/backend.js
+++ b/installed-tests/fixtures/backend.js
@@ -5,6 +5,7 @@
 'use strict';
 
 const Gio = imports.gi.Gio;
+const GioUnix = imports.gi.GioUnix;
 const GLib = imports.gi.GLib;
 const GObject = imports.gi.GObject;
 
@@ -127,7 +128,7 @@ var ChannelService = GObject.registerClass({
 
             // Input stream
             this._udp6_stream = new Gio.DataInputStream({
-                base_stream: new Gio.UnixInputStream({
+                base_stream: new GioUnix.InputStream({
                     fd: this._udp6.fd,
                     close_fd: false,
                 }),
@@ -159,7 +160,7 @@ var ChannelService = GObject.registerClass({
 
             // Input stream
             this._udp4_stream = new Gio.DataInputStream({
-                base_stream: new Gio.UnixInputStream({
+                base_stream: new GioUnix.InputStream({
                     fd: this._udp4.fd,
                     close_fd: false,
                 }),

--- a/installed-tests/fixtures/backend.js
+++ b/installed-tests/fixtures/backend.js
@@ -5,12 +5,22 @@
 'use strict';
 
 const Gio = imports.gi.Gio;
-const GioUnix = imports.gi.GioUnix;
 const GLib = imports.gi.GLib;
 const GObject = imports.gi.GObject;
 
 const Config = imports.config;
 const Core = imports.service.core;
+
+// Retain compatibility with GLib < 2.80, which lacks GioUnix
+let GioUnix;
+try {
+    GioUnix = imports.gi.GioUnix;
+} catch (e) {
+    GioUnix = {
+        InputStream: Gio.UnixInputStream,
+        OutputStream: Gio.UnixOutputStream,
+    };
+}
 
 
 /**

--- a/src/gsconnect-preferences
+++ b/src/gsconnect-preferences
@@ -11,6 +11,7 @@
 imports.gi.versions.Gdk = '3.0';
 imports.gi.versions.GdkPixbuf = '2.0';
 imports.gi.versions.Gio = '2.0';
+imports.gi.versions.GioUnix = '2.0';
 imports.gi.versions.GLib = '2.0';
 imports.gi.versions.GObject = '2.0';
 imports.gi.versions.Gtk = '3.0';

--- a/src/service/backends/lan.js
+++ b/src/service/backends/lan.js
@@ -5,7 +5,7 @@
 'use strict';
 
 const Gio = imports.gi.Gio;
-const GioUnix = imports.GioUnix;
+const GioUnix = imports.gi.GioUnix;
 const GLib = imports.gi.GLib;
 const GObject = imports.gi.GObject;
 

--- a/src/service/backends/lan.js
+++ b/src/service/backends/lan.js
@@ -5,13 +5,22 @@
 'use strict';
 
 const Gio = imports.gi.Gio;
-const GioUnix = imports.gi.GioUnix;
 const GLib = imports.gi.GLib;
 const GObject = imports.gi.GObject;
 
 const Config = imports.config;
 const Core = imports.service.core;
 
+// Retain compatibility with GLib < 2.80, which lacks GioUnix
+let GioUnix;
+try {
+    GioUnix = imports.gi.GioUnix;
+} catch (e) {
+    GioUnix = {
+        InputStream: Gio.UnixInputStream,
+        OutputStream: Gio.UnixOutputStream,
+    };
+}
 
 /**
  * TCP Port Constants

--- a/src/service/backends/lan.js
+++ b/src/service/backends/lan.js
@@ -5,6 +5,7 @@
 'use strict';
 
 const Gio = imports.gi.Gio;
+const GioUnix = imports.GioUnix;
 const GLib = imports.gi.GLib;
 const GObject = imports.gi.GObject;
 
@@ -264,7 +265,7 @@ var ChannelService = GObject.registerClass({
 
             // Input stream
             this._udp6_stream = new Gio.DataInputStream({
-                base_stream: new Gio.UnixInputStream({
+                base_stream: new GioUnix.InputStream({
                     fd: this._udp6.fd,
                     close_fd: false,
                 }),
@@ -296,7 +297,7 @@ var ChannelService = GObject.registerClass({
 
             // Input stream
             this._udp4_stream = new Gio.DataInputStream({
-                base_stream: new Gio.UnixInputStream({
+                base_stream: new GioUnix.InputStream({
                     fd: this._udp4.fd,
                     close_fd: false,
                 }),

--- a/src/service/daemon.js
+++ b/src/service/daemon.js
@@ -9,6 +9,7 @@
 imports.gi.versions.Gdk = '3.0';
 imports.gi.versions.GdkPixbuf = '2.0';
 imports.gi.versions.Gio = '2.0';
+imports.gi.versions.GioUnix = '2.0';
 imports.gi.versions.GIRepository = '2.0';
 imports.gi.versions.GLib = '2.0';
 imports.gi.versions.GObject = '2.0';

--- a/src/service/nativeMessagingHost.js
+++ b/src/service/nativeMessagingHost.js
@@ -7,10 +7,12 @@
 'use strict';
 
 imports.gi.versions.Gio = '2.0';
+imports.gi.versions.GioUnix = '2.0';
 imports.gi.versions.GLib = '2.0';
 imports.gi.versions.GObject = '2.0';
 
 const Gio = imports.gi.Gio;
+const GioUnix = imports.gi.GioUnix;
 const GLib = imports.gi.GLib;
 const GObject = imports.gi.GObject;
 const System = imports.system;
@@ -44,12 +46,12 @@ const NativeMessagingHost = GObject.registerClass({
 
         // IO Channels
         this._stdin = new Gio.DataInputStream({
-            base_stream: new Gio.UnixInputStream({fd: 0}),
+            base_stream: new GioUnix.InputStream({fd: 0}),
             byte_order: Gio.DataStreamByteOrder.HOST_ENDIAN,
         });
 
         this._stdout = new Gio.DataOutputStream({
-            base_stream: new Gio.UnixOutputStream({fd: 1}),
+            base_stream: new GioUnix.OutputStream({fd: 1}),
             byte_order: Gio.DataStreamByteOrder.HOST_ENDIAN,
         });
 

--- a/src/service/nativeMessagingHost.js
+++ b/src/service/nativeMessagingHost.js
@@ -12,10 +12,20 @@ imports.gi.versions.GLib = '2.0';
 imports.gi.versions.GObject = '2.0';
 
 const Gio = imports.gi.Gio;
-const GioUnix = imports.gi.GioUnix;
 const GLib = imports.gi.GLib;
 const GObject = imports.gi.GObject;
 const System = imports.system;
+
+// Retain compatibility with GLib < 2.80, which lacks GioUnix
+let GioUnix;
+try {
+    GioUnix = imports.gi.GioUnix;
+} catch (e) {
+    GioUnix = {
+        InputStream: Gio.UnixInputStream,
+        OutputStream: Gio.UnixOutputStream,
+    };
+}
 
 
 const NativeMessagingHost = GObject.registerClass({


### PR DESCRIPTION
Seems `Gio` has been fragmented, its platform-specific classes are now part of a separate [`GioUnix`](https://docs.gtk.org/gio-unix/index.html) library.

Fixes #1781 