### PR TITLE
mount /sdcard/

### DIFF
--- a/src/service/plugins/sftp.js
+++ b/src/service/plugins/sftp.js
@@ -222,7 +222,7 @@ const SFTPPlugin = GObject.registerClass({
 
             // This is the actual call to mount the device
             const host = this.device.channel.host;
-            const uri = `sftp://${host}:${packet.body.port}/`;
+            const uri = `sftp://${host}:${packet.body.port}/sdcard/`;
             const file = Gio.File.new_for_uri(uri);
 
             await file.mount_enclosing_volume(GLib.PRIORITY_DEFAULT, op,


### PR DESCRIPTION
most devices or kde connect app don't have root access

currently when i click on "mount" in gsconnect it opens `sftp://192.168.178.21:1740/` which does not work.
`sftp://192.168.178.21:1740/sdcard/ works however, so i hope this is the correct fix