### PR TITLE
 mount /sdcard/

### DIFF
--- a/src/service/plugins/sftp.js
+++ b/src/service/plugins/sftp.js
@@ -222,7 +222,7 @@ const SFTPPlugin = GObject.registerClass({
 
             // This is the actual call to mount the device
             const host = this.device.channel.host;
-            const uri = `sftp://${host}:${packet.body.port}/`;
+            const uri = `sftp://${host}:${packet.body.port}/sdcard/`;
             const file = Gio.File.new_for_uri(uri);
 
             await file.mount_enclosing_volume(GLib.PRIORITY_DEFAULT, op,


### PR DESCRIPTION
android apps without root access and permission granted `MANAGE_EXTERNAL_STORAGE` can only access `/sdcard/`

when trying to access `sftp://192.168.178.21:1739/` this error appears: 
![image](https://github.com/GSConnect/gnome-shell-extension-gsconnect/assets/38194372/e90d7893-12d5-402e-bff7-4c6b9c05665e)

after appending `/sdcard/` to the sftp uri, i was able to successfully connect:
![image](https://github.com/GSConnect/gnome-shell-extension-gsconnect/assets/38194372/ce5b559e-c564-4ab9-aed9-b36eaccf1eba)