### PR TITLE
enhancement: Add received file to recent file list 

### DIFF
--- a/src/service/plugins/share.js
+++ b/src/service/plugins/share.js
@@ -196,7 +196,7 @@ const SharePlugin = GObject.registerClass({
                 ];
                 iconName = 'document-save-symbolic';
 
-                let gtk_recent_manager = Gtk.RecentManager.get_default();
+                const gtk_recent_manager = Gtk.RecentManager.get_default();
                 gtk_recent_manager.add_item(file.get_uri());
 
                 if (packet.body.open) {

--- a/src/service/plugins/share.js
+++ b/src/service/plugins/share.js
@@ -196,6 +196,9 @@ const SharePlugin = GObject.registerClass({
                 ];
                 iconName = 'document-save-symbolic';
 
+                let gtk_recent_manager = Gtk.RecentManager.get_default();
+                gtk_recent_manager.add_item(file.get_uri());
+
                 if (packet.body.open) {
                     const uri = file.get_uri();
                     Gio.AppInfo.launch_default_for_uri_async(uri, null, null, null);


### PR DESCRIPTION
## What does this PR do?

Whenever we send files from mobile to desktop, It adds the file into recent menu

## Test

1. Send a file from mobile
2. After successful transmission of file, check Recent file.

## Related PRs and Issues
- Fixes #1743 

## Test Video

https://github.com/GSConnect/gnome-shell-extension-gsconnect/assets/111437670/4991c299-c29f-41d1-b03a-bf8fb0f9c60b

