### PR TITLE
Fix sender parameter of .signal_subscribe

### DIFF
--- a/src/service/components/clipboard.js
+++ b/src/service/components/clipboard.js
@@ -99,7 +99,7 @@ const Clipboard = GObject.registerClass({
             if (!globalThis.HAVE_GNOME) {
                 // Directly subscrible signal
                 this.signalHandler = Gio.DBus.session.signal_subscribe(
-                    DBUS_NAME,
+                    null,
                     DBUS_NAME,
                     'OwnerChange',
                     DBUS_PATH,


### PR DESCRIPTION
Note: this fix is intented for gsconnect users without GNOME installed.

Recently, it seems that one cannot acquire a proper sender name automatically when using `dbus-send` command in a Gio.Subprocess. The command is issued in wl_clipboard.js:
```
wl-paste -w dbus-send /org/gnome/Shell/Extensions/GSConnect/Clipboard --dest=org.gnome.Shell.Extensions.GSConnect.Clipboard org.gnome.Shell.Extensions.GSConnect.Clipboard.OwnerChange
```

To fix this issue, we have to set the sender parameter of the method Gio.DBusConnection.signal_subscribe to be null.
See docs at: https://docs.gtk.org/gio/method.DBusConnection.signal_subscribe.html