### PR TITLE
Feature: Add multiple file transfer, directory transfer from Nautilus

### DIFF
--- a/nautilus-extension/nautilus-gsconnect.py
+++ b/nautilus-extension/nautilus-gsconnect.py
@@ -11,9 +11,13 @@ developers for the sister Python script 'kdeconnect-send-nautilus.py':
 https://github.com/Bajoja/indicator-kdeconnect/blob/master/data/extensions/kdeconnect-send-nautilus.py
 """
 
-import gettext
 import os.path
+import pathlib
 import sys
+import tempfile
+import zipfile
+import typing as T
+from gettext import translation, GNUTranslations, NullTranslations
 
 import gi
 
@@ -41,27 +45,25 @@ SERVICE_NAME = "org.gnome.Shell.Extensions.GSConnect"
 SERVICE_PATH = "/org/gnome/Shell/Extensions/GSConnect"
 
 # Init gettext translations
-LOCALE_DIR = os.path.join(
+locale_path = os.path.join(
     GLib.get_user_data_dir(),
     "gnome-shell",
     "extensions",
     "gsconnect@andyholmes.github.io",
     "locale",
 )
+LOCALE_DIR = locale_path if os.path.exists(locale_path) else None
 
-if not os.path.exists(LOCALE_DIR):
-    LOCALE_DIR = None
-
+i18n: GNUTranslations | NullTranslations = NullTranslations()
 try:
-    i18n = gettext.translation(SERVICE_NAME, localedir=LOCALE_DIR)
-    _ = i18n.gettext
-
+    i18n = translation(SERVICE_NAME, localedir=LOCALE_DIR)
 except (IOError, OSError) as e:
-    print("GSConnect: {0}".format(str(e)))
-    i18n = gettext.translation(
+    print(f"GSConnect: {e}", file=sys.stdout)
+    i18n = translation(
         SERVICE_NAME, localedir=LOCALE_DIR, fallback=True
     )
-    _ = i18n.gettext
+
+_ = i18n.gettext
 
 
 class GSConnectShareExtension(GObject.Object, FileManager.MenuProvider):
@@ -72,6 +74,7 @@ class GSConnectShareExtension(GObject.Object, FileManager.MenuProvider):
         GObject.Object.__init__(self)
 
         self.devices = {}
+        self.tempdir = None
 
         Gio.DBusProxy.new_for_bus(
             Gio.BusType.SESSION,
@@ -146,11 +149,60 @@ class GSConnectShareExtension(GObject.Object, FileManager.MenuProvider):
                 ),
             )
 
-    def send_files(self, menu, files, action_group):
+    def make_temporary_zipfile(self, dir):
+        """Recursively walk ``dir`` and create a zipfile, returning its URI."""
+        if self.tempdir is None:
+            self.tempdir = tempfile.mkdtemp(prefix='gsconnect')
+        dirpath = pathlib.Path(dir)
+        zippath = pathlib.Path(self.tempdir) / dirpath.with_suffix('.zip').name
+        with zipfile.ZipFile(zippath, "w") as z:
+            for parent, subdirs, subfiles in dirpath.walk():
+                # Create directory entries, to include empty directories
+                indir = parent.resolve()
+                arcdir = parent.relative_to(dirpath.parent)
+                z.write(indir, arcname=arcdir)
+                for file in subfiles:
+                    try:
+                        infile = indir / file
+                        arcfile = arcdir / file
+                        z.write(infile, arcname=str(arcfile))
+                    except OSError as e:
+                        print(
+                            f"GSConnect: Can't add {arcfile} to zip: {e}",
+                            file=sys.stderr)
+                        continue
+        return zippath.as_uri()
+
+    def send_files(
+            self, menu, selected: list[FileManager.FileInfo], action_group):
         """Send *files* to *device_id*."""
-        for file in files:
-            variant = GLib.Variant("(sb)", (file.get_uri(), False))
-            action_group.activate_action("shareFile", variant)
+        all_files = set(selected)
+
+        if not all_files:
+            return
+
+        dirs = set(filter(lambda f: f.is_directory(), all_files))
+        files = all_files - dirs
+
+        file_uris = [f.get_uri() for f in files]
+
+        if files and not dirs:
+            files_variant = GLib.Variant("(asb)", (file_uris, False))
+            action_group.activate_action("shareFiles", files_variant)
+            return
+
+        # Handle temporary zip files for dirs
+        # XXX: This currently names the zipfiles 'basename.zip' and
+        #      DOES NOT handle collisions. Don't try to send two
+        #      directories both named "Documents". The two
+        #      "Documents.zip" archives will overwrite each other!
+        zip_uris = [
+            self.make_temporary_zipfile(dir.get_location().get_path())
+            for dir in dirs
+        ]
+        file_uris.extend(zip_uris)
+        mixed_variant = GLib.Variant("(asas)", (file_uris, zip_uris))
+        action_group.activate_action("shareFilesWithTemps", mixed_variant)
 
     def get_file_items(self, *args):
         """Return a list of select files to be sent."""
@@ -159,54 +211,52 @@ class GSConnectShareExtension(GObject.Object, FileManager.MenuProvider):
         #     `[files: List[Nautilus.FileInfo]]`
         # * Nautilus 3.0:
         #     `[window: Gtk.Widget, files: List[Nautilus.FileInfo]]`
-        files = args[-1]
+        files = set(args[-1])
 
         # Only accept regular files
         for uri in files:
-            if uri.get_uri_scheme() != "file" or uri.is_directory():
+            if uri.get_uri_scheme() != "file":
                 return ()
 
         # Enumerate capable devices
-        devices = []
-
-        for name, action_group in self.devices.values():
-            if action_group.get_action_enabled("shareFile"):
-                devices.append([name, action_group])
+        devices = {
+            name: action_group
+            for name, action_group in self.devices.values()
+            if action_group.get_action_enabled("shareFile")
+        }
 
         # No capable devices; don't show menu entry
         if not devices:
             return ()
 
-        # If there's exactly 1 device, no submenu
-        if len(devices) == 1:
-            name, action_group = devices[0]
-            menu = FileManager.MenuItem(
-                name="GSConnectShareExtension::Device" + name,
-                # TRANSLATORS: Send to <device_name>, for file manager
-                # context menu
-                label=_("Send to %s") % name,
+        # Context Submenu Items
+        def make_submenu_item(name, action_group, files):
+            """Generate a send-to-device context menu item."""
+            item = FileManager.MenuItem(
+                name="GSConnectShareExtension::Device" + name, label=name
             )
-            menu.connect("activate", self.send_files, files, action_group)
+            item.connect("activate", self.send_files, list(files), action_group)
+            return item
+        submenu_items = {
+            name: make_submenu_item(name, action_group, files)
+            for name, action_group in devices.items()
+        }
 
+        if len(submenu_items) == 1:
+            # Single entry for FileManager econtext menu
+            name, menu = submenu_items.popitem()
+            # TRANSLATORS: Send to <device_name>, for file manager
+            # context menu
+            menu.set_label(_("Send to %s") % name)
         else:
-            # Context Menu Item
+            # Submenu for FileManager context menu
             menu = FileManager.MenuItem(
                 name="GSConnectShareExtension::Devices",
                 label=_("Send To Mobile Device"),
             )
-
-            # Context Submenu
             submenu = FileManager.Menu()
             menu.set_submenu(submenu)
-
-            # Context Submenu Items
-            for name, action_group in devices:
-                item = FileManager.MenuItem(
-                    name="GSConnectShareExtension::Device" + name, label=name
-                )
-
-                item.connect("activate", self.send_files, files, action_group)
-
+            for item in submenu_items.values():
                 submenu.append_item(item)
 
         return (menu,)

--- a/src/service/core.js
+++ b/src/service/core.js
@@ -492,6 +492,8 @@ export const Transfer = GObject.registerClass({
 
         this._cancellable = new Gio.Cancellable();
         this._items = [];
+        this._count = 0;
+        this._totalSize = 0;
     }
 
     get channel() {
@@ -564,15 +566,20 @@ export const Transfer = GObject.registerClass({
                 const read = item.file.read_async(GLib.PRIORITY_DEFAULT,
                     cancellable);
 
-                const query = item.file.query_info_async(
-                    Gio.FILE_ATTRIBUTE_STANDARD_SIZE,
-                    Gio.FileQueryInfoFlags.NONE,
-                    GLib.PRIORITY_DEFAULT,
-                    cancellable);
+                if (!item.hasOwnProperty('size') || item.size === null) {
+                    const query = item.file.query_info_async(
+                        Gio.FILE_ATTRIBUTE_STANDARD_SIZE,
+                        Gio.FileQueryInfoFlags.NONE,
+                        GLib.PRIORITY_DEFAULT,
+                        cancellable);
 
-                const [stream, info] = await Promise.all([read, query]);
-                item.source = stream;
-                item.size = info.get_size();
+                    const [stream, info] = await Promise.all([read, query]);
+                    item.source = stream;
+                    item.size = info.get_size();
+                } else {
+                    const stream = await read;
+                    item.source = stream;
+                }
             }
         }
     }
@@ -582,13 +589,15 @@ export const Transfer = GObject.registerClass({
      *
      * @param {Core.Packet} packet - A packet
      * @param {Gio.File} file - A file to transfer
+     * @param {number} [size] - The file size in bytes
      */
-    addFile(packet, file) {
+    addFile(packet, file, size = null) {
         const item = {
             packet: new Packet(packet),
             file: file,
             source: null,
             target: null,
+            size: size,
         };
 
         this._items.push(item);
@@ -606,6 +615,7 @@ export const Transfer = GObject.registerClass({
             file: Gio.File.new_for_path(path),
             source: null,
             target: null,
+            size: null,
         };
 
         this._items.push(item);
@@ -633,6 +643,33 @@ export const Transfer = GObject.registerClass({
             item.target = stream;
 
         this._items.push(item);
+    }
+
+    /**
+     * Set metadata for the transfer group
+     *
+     * @param {number} numberOfFiles - Count of files to send/receive
+     * @param {number} totalPayloadSize - Combined size, in bytes
+     */
+    setCountAndSize(numberOfFiles, totalPayloadSize) {
+        this._count = numberOfFiles;
+        this._totalSize = totalPayloadSize;
+
+        const item = {
+            packet: new Packet({
+                type: 'kdeconnect.share.request.update',
+                body: {
+                    numberOfFiles: this._count,
+                    totalPayloadSize: this._totalSize,
+                }
+            }),
+            file: null,
+            source: null,
+            target: null,
+            size: null,
+        };
+
+        this._items.unshift(item);
     }
 
     /**
@@ -665,14 +702,23 @@ export const Transfer = GObject.registerClass({
                     });
                 }
 
-                await this._ensureStream(item, this._cancellable);
-
-                if (item.packet.hasPayload()) {
-                    await this.channel.download(item.packet, item.target,
-                        this._cancellable);
+                if (item.packet.type === 'kdeconnect.share.request.update') {
+                    debug("Sending update packet");
+                    debug(item.packet);
+                    await this.channel.sendPacket(
+                        item.packet, this._cancellable);
                 } else {
-                    await this.channel.upload(item.packet, item.source,
-                        item.size, this._cancellable);
+                    await this._ensureStream(item, this._cancellable);
+
+                    if (item.packet.hasPayload()) {
+                        await this.channel.download(item.packet, item.target,
+                            this._cancellable);
+                    } else {
+                        item.packet.body.numberOfFiles = this._count;
+                        item.packet.body.totalPayloadSize = this._totalSize;
+                        await this.channel.upload(item.packet, item.source,
+                            item.size, this._cancellable);
+                    }
                 }
             }
         } catch (e) {
@@ -691,4 +737,3 @@ export const Transfer = GObject.registerClass({
             this._cancellable.cancel();
     }
 });
-

--- a/src/service/plugins/share.js
+++ b/src/service/plugins/share.js
@@ -19,7 +19,7 @@ export const Metadata = {
     incomingCapabilities: ['kdeconnect.share.request'],
     outgoingCapabilities: [
         'kdeconnect.share.request',
-        'kdeconnect.share.request.update'
+        'kdeconnect.share.request.update',
     ],
     actions: {
         share: {
@@ -51,6 +51,8 @@ export const Metadata = {
         },
         shareFilesWithTemps: {
             label: _('Share Files (including temporaries)'),
+
+            parameter_type: new GLib.VariantType('(asas)'),
             incoming: [],
             outgoing: [
                 'kdeconnect.share.request',
@@ -399,13 +401,14 @@ const SharePlugin = GObject.registerClass({
                 const info = await file.query_info_async(
                     Gio.FILE_ATTRIBUTE_STANDARD_SIZE,
                     Gio.FileQueryInfoFlags.NONE,
-                    GLib.PRIORITY_DEFAULT
+                    GLib.PRIORITY_DEFAULT,
+                    null
                 );
 
                 const filesize = info.get_size();
                 payload_size += filesize;
 
-                const delete_after = tempList.contains(path);
+                const delete_after = tempList.includes(path);
 
                 packet_list.push([
                     {
@@ -643,12 +646,11 @@ const FileChooserDialog = GObject.registerClass({
     vfunc_response(response_id) {
         if (response_id === Gtk.ResponseType.OK) {
             const uris = [];
-            for (const uri of this.get_uris()) {
-            	uris.push(uri);
-            }
+            for (const uri of this.get_uris())
+                uris.push(uri);
             const parameters = new GLib.Variant('(asb)', [
-            	uris,
-            	this.extra_widget.active,
+                uris,
+                this.extra_widget.active,
             ]);
             debug(parameters.deepUnpack());
             this.device.activate_action('shareFiles', parameters);


### PR DESCRIPTION
This PR adds the ability to transfer multiple files at once over the KDEConnect "share files" link, and upgrades the Nautilus/Nemo extension with the ability to both handle multi-select (sending all of the selected items), _and_ to send directory trees via a temporarily-created `.zip` file, which are deleted by the JS code after transferring the files (successfully or not).

Fixes: #1025 