### PR TITLE
Python flake8: Set max line length to 80

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,3 +4,5 @@
 
 [flake8]
 extend-ignore = E402
+max-line-length = 80
+


### PR DESCRIPTION
Cherry-picked from my #1821, this increases the `flake8` maximum line length to `80` (from the default `79`), to avoid an annoying cycle where Black would format a line of exactly 80 characters to one line, but then `flake8` would complain and want it wrapped, but then `black` would reformat it back to one line...
