### PR TITLE
Raise remote input timeout to 300 seconds

### DIFF
--- a/src/service/components/input.js
+++ b/src/service/components/input.js
@@ -10,7 +10,7 @@ import GObject from 'gi://GObject';
 import AtspiController from './atspi.js';
 
 
-const SESSION_TIMEOUT = 15;
+const SESSION_TIMEOUT = 300;
 
 
 const RemoteSession = GObject.registerClass({


### PR DESCRIPTION
The first input event on reconnection is currently being lost, this should make reconnections much less frequent. See #1836.

I don't want to mark that issue as _fixed_ with this, since it's really just a workaround until we can figure out why input events are being lost. See my comment on the issue for more detail(/confused ramblings).