### PR TITLE
Use layoutManager.addTopChrome() for tooltips

### DIFF
--- a/src/shell/tooltip.js
+++ b/src/shell/tooltip.js
@@ -170,8 +170,7 @@ export default class Tooltip {
                 this._bin.child.add_child(this.label);
             }
 
-            Main.layoutManager.uiGroup.add_child(this._bin);
-            Main.layoutManager.uiGroup.set_child_above_sibling(this._bin, null);
+            Main.layoutManager.addTopChrome(this._bin);
         } else if (this.custom) {
             this._bin.child = this.custom;
         } else {
@@ -234,7 +233,7 @@ export default class Tooltip {
                 time: 0.10,
                 transition: Clutter.AnimationMode.EASE_OUT_QUAD,
                 onComplete: () => {
-                    Main.layoutManager.uiGroup.remove_actor(this._bin);
+                    Main.layoutManager.removeChrome(this._bin);
 
                     if (this.custom)
                         this._bin.remove_child(this.custom);
@@ -291,7 +290,7 @@ export default class Tooltip {
             this.custom.destroy();
 
         if (this._bin) {
-            Main.layoutManager.uiGroup.remove_actor(this._bin);
+            Main.layoutManager.removeChrome(this._bin);
             this._bin.destroy();
         }
 
@@ -306,4 +305,3 @@ export default class Tooltip {
         }
     }
 }
-


### PR DESCRIPTION
This may be an abuse of the API, but attempting to manage our tooltip actors with `uiGroup.add_actor()` and `uiGroup.remove_actor()` was causing all of:
1. 'Main.layoutManager.uiGroup.remove_actor is not a function' errors in the journal.
2. leaked tooltip objects collecting in the uiGroup (as observed using the Looking Glass 'Actors' panel).
3. tooltips frequently appearing _below_ the user menu.

The layout manager's `addTopChrome()` was explicitly created "To insert actors at the top of uiGroup". Its `removeChrome()` calls seem to always succeed, where attempts to call `uiGroup.remove_actor()` regularly throw `TypeError`s.

In testing this on my system, the switch to using `addTopChrome()` and `removeChrome()` resulted in the tooltips always showing up above the user menu, and always being cleaned up promptly instead of accumulating as children of the `uiGroup`.

Fixes #1850

@andyholmes, any thoughts on whether this is kosher / a good idea?