### PR TITLE
Focus the "Share" file-chooser dialog's URI-entry field, when activated

### DIFF
--- a/src/service/plugins/share.js
+++ b/src/service/plugins/share.js
@@ -452,11 +452,13 @@ const FileChooserDialog = GObject.registerClass({
     _onUriButtonToggled(button) {
         const header = this.get_header_bar();
 
-        // Show the URL entry
+        // Show and focus the URL entry
         if (button.active) {
             this.extra_widget.sensitive = false;
             header.set_custom_title(this._uriEntry);
+            this._uriEntry.grab_focus();
             this.set_response_sensitive(Gtk.ResponseType.OK, true);
+
 
         // Hide the URL entry
         } else {

--- a/src/service/plugins/share.js
+++ b/src/service/plugins/share.js
@@ -459,7 +459,6 @@ const FileChooserDialog = GObject.registerClass({
             this._uriEntry.grab_focus();
             this.set_response_sensitive(Gtk.ResponseType.OK, true);
 
-
         // Hide the URL entry
         } else {
             header.set_custom_title(null);


### PR DESCRIPTION
Fixes #1849 
