### PR TITLE
Don't re-show repeated notifications

### DIFF
--- a/src/shell/notification.js
+++ b/src/shell/notification.js
@@ -239,19 +239,20 @@ const Source = GObject.registerClass({
         if (cachedNotification) {
             cachedNotification.requestReplyId = requestReplyId;
 
-            // Bail early If @notificationParams represents an exact repeat
             const title = notification.title;
             const body = notification.body
                 ? notification.body
                 : null;
 
+            // Bail early If @notification represents an exact repeat
             if (cachedNotification.title === title &&
                 cachedNotification.body === body)
                 return cachedNotification;
 
+            // If the details have changed, flag as an update
             cachedNotification.title = title;
             cachedNotification.body = body;
-
+            cachedNotification.acknowledged = false;
             return cachedNotification;
         }
 
@@ -304,10 +305,8 @@ const Source = GObject.registerClass({
      * notification limit (3)
      */
     _addNotificationToMessageTray(notification) {
-        if (this.notifications.includes(notification)) {
-            notification.acknowledged = false;
+        if (this.notifications.includes(notification))
             return;
-        }
 
         while (this.notifications.length >= 10) {
             const [oldest] = this.notifications;


### PR DESCRIPTION
GSConnect receives a lot of duplicate notifications, whether due to reconnects, proactively requesting updates, etc.

Since GNOME 46, each of those repeats has been popped up as a new banner notification every time it's received, even if nothing has changed in the notification content. This is extremely disruptive.

To avoid that, don't blindly flag all repeated notifications as "unacknowledged", which will cause them to be popped up again. Only do so if the content has changed. (This covers re-displaying banners for SMS conversations that receive an additional message, since those are sent as updates to the existing notification.)

Fixes #1855