### PR TITLE
Move ownership/control of debug signal to GObject

### DIFF
--- a/src/service/init.js
+++ b/src/service/init.js
@@ -138,20 +138,17 @@ const _debugFunc = function (error, prefix = null) {
     });
 };
 
-// Swap the function out for a no-op anonymous function for speed
+globalThis._debugFunc = _debugFunc;
+
 const settings = new Gio.Settings({
     settings_schema: Config.GSCHEMA.lookup(Config.APP_ID, true),
 });
-
-settings.connect('changed::debug', (settings, key) => {
-    globalThis.debug = settings.get_boolean(key) ? _debugFunc : () => {};
-});
-
-if (settings.get_boolean('debug'))
-    globalThis.debug = _debugFunc;
-else
+if (settings.get_boolean('debug')) {
+    globalThis.debug = globalThis._debugFunc;
+} else {
+    // Swap the function out for a no-op anonymous function for speed
     globalThis.debug = () => {};
-
+}
 
 /**
  * Start wl_clipboard if not under Gnome


### PR DESCRIPTION
We've been having a problem in GNOME 46 with GSConnect not responding
to the toggling of the "debug" setting, seemingly not being delivered
the `changed::debug` signal at all. Let's make it a property of the
`GSConnectManager` GObject instead.

Fixes #1862