### PR TITLE
Add GNOME 47 to version list

### DIFF
--- a/data/metadata.json.in
+++ b/data/metadata.json.in
@@ -3,6 +3,6 @@
     "name": "GSConnect",
     "description": "GSConnect is a complete implementation of KDE Connect especially for GNOME Shell with Nautilus, Chrome and Firefox integration. It does not rely on the KDE Connect desktop application and will not work with it installed.\n\nKDE Connect allows devices to securely share content like notifications or files and other features like SMS messaging and remote control. The KDE Connect team has applications for Linux, BSD, Android, Sailfish, iOS, macOS and Windows.\n\nPlease report issues on Github!",
     "version": @PACKAGE_VERSION@,
-    "shell-version": [ "46" ],
+    "shell-version": [ "46", "47" ],
     "url": "@PACKAGE_URL@/wiki"
 }


### PR DESCRIPTION
AFAICT based on https://gjs.guide/extensions/upgrading/gnome-shell-47.html, there's nothing else to do for compatibility.

Fixes #1863

I think once this and #1860 are merged, it's probably time for a release. There are several unreleased fixes GNOME 46 users will benefit from, as well.
