### PR TITLE
Release V58

### DIFF
--- a/data/metainfo/org.gnome.Shell.Extensions.GSConnect.metainfo.xml.in
+++ b/data/metainfo/org.gnome.Shell.Extensions.GSConnect.metainfo.xml.in
@@ -58,6 +58,9 @@ SPDX-License-Identifier: CC0-1.0
   </description>
 
   <releases>
+    <release version="58" date="2024-10-24">
+      <url>https://github.com/GSConnect/gnome-shell-extension-gsconnect/releases/tag/v58</url>
+    </release>
     <release version="57" date="2023-11-05">
       <url>https://github.com/GSConnect/gnome-shell-extension-gsconnect/releases/tag/v57</url>
     </release>

--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,7 @@
 
 project('gsconnect',
   'c',
-  version: '57',
+  version: '58',
   meson_version: '>= 0.59.0',
 )
 


### PR DESCRIPTION
Tentative/WIP release PR for GSConnect v58.

Should not be merged without #1866.

See review comments below, as well.