### PR TITLE
Clipboard: Block proxying of passwords

### DIFF
--- a/src/service/components/clipboard.js
+++ b/src/service/components/clipboard.js
@@ -192,6 +192,14 @@ const Clipboard = GObject.registerClass({
         if (mimetypes.includes('text/uri-list'))
             return;
 
+        // Special case to avoid copying identifiable passwords,
+        // for privacy reasons.
+        // (See https://github.com/GSConnect/gnome-shell-extension-gsconnect/issues/1893)
+        // TODO: Should there be a preference to re-enable password-sharing,
+        // for users who desire it?
+        if (mimetypes.includes('x-kde-passwordManagerHint'))
+            return;
+
         const text = await new Promise((resolve, reject) => {
             this._clipboard.request_text((clipboard, text) => resolve(text));
         });


### PR DESCRIPTION
Since some password managers set a clipboard mimetype to signal when the clipboard contains password data, ignore the clipboard contents in those cases, to avoid exposing passwords over the link to the mobile device.

Fixes: #1893