### PR TITLE
Changed 'connect to' to 'Add Device by IP'

### DIFF
--- a/data/ui/preferences-window.ui
+++ b/data/ui/preferences-window.ui
@@ -818,7 +818,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
     <section>
       <item>
         <!-- TRANSLATORS: Open a dialog to connect to an IP or Bluez device -->
-        <attribute name="label" translatable="yes">Add device by IP...</attribute>
+        <attribute name="label" translatable="yes">Add device by IP…</attribute>
         <attribute name="action">win.connect</attribute>
       </item>
     </section>

--- a/data/ui/preferences-window.ui
+++ b/data/ui/preferences-window.ui
@@ -818,7 +818,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
     <section>
       <item>
         <!-- TRANSLATORS: Open a dialog to connect to an IP or Bluez device -->
-        <attribute name="label" translatable="yes">Add devices by IP</attribute>
+        <attribute name="label" translatable="yes">Add device by IP...</attribute>
         <attribute name="action">win.connect</attribute>
       </item>
     </section>

--- a/data/ui/preferences-window.ui
+++ b/data/ui/preferences-window.ui
@@ -818,7 +818,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
     <section>
       <item>
         <!-- TRANSLATORS: Open a dialog to connect to an IP or Bluez device -->
-        <attribute name="label" translatable="yes">Connect to…</attribute>
+        <attribute name="label" translatable="yes">Add devices by IP</attribute>
         <attribute name="action">win.connect</attribute>
       </item>
     </section>


### PR DESCRIPTION
Changed the "connect to" option to "Add devices by IP"
![image](https://github.com/user-attachments/assets/9349385d-31f8-4891-921b-d3c2ad4315e7)

Fixes #1886 
