### PR TITLE
contacts: Fix SourceRegistry

### DIFF
--- a/src/service/components/contacts.js
+++ b/src/service/components/contacts.js
@@ -267,7 +267,7 @@ const Store = GObject.registerClass({
             this._ebooks = new Map();
 
             // Get the current EBooks
-            const registry = await this._getESourceRegistry();
+            const registry = await EDataServer.SourceRegistry.new(null);
 
             for (const source of registry.list_sources('Address Book'))
                 await this._onAppeared(null, source);


### PR DESCRIPTION
When the codebase was promisified in ab97043, the local function `_getESourceRegistry()` was removed, but a call to it was missed. Replace with a direct call to the promisified `EDataServer.SourceRegistry.new()` constructor.

Fixes #1916

I'm frankly shocked that it's taken this long for someone to report this, as the removal of `_getESourceRegistry()` happened in August 2023! But, here we are.
