### PR TITLE
Clear up all ESLint warnings from jsdoc plugin

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -233,6 +233,8 @@ export default [
             '@stylistic/js/wrap-iife': ['error', 'inside'],
             '@stylistic/js/yield-star-spacing': 'error',
             yoda: 'error',
+
+            'jsdoc/tag-lines': ['error', 'any', {'startLines': 1}],
         },
     },
     {

--- a/installed-tests/fixtures/components/mpris.js
+++ b/installed-tests/fixtures/components/mpris.js
@@ -22,7 +22,7 @@ const MockMediaPlayer = GObject.registerClass({
     /**
      * Update the player with an object of properties and values.
      *
-     * @param {Object} obj - A dictionary of properties
+     * @param {object} obj - A dictionary of properties
      */
     update(obj) {
         for (const [propertyName, propertyValue] of Object.entries(obj))
@@ -184,4 +184,3 @@ const Component = GObject.registerClass({
 });
 
 export default Component;
-

--- a/installed-tests/fixtures/components/session.js
+++ b/installed-tests/fixtures/components/session.js
@@ -26,11 +26,10 @@ export default class MockSessionComponent {
     /**
      * Update the session with an object of properties and values.
      *
-     * @param {Object} obj - A dictionary of properties
+     * @param {object} obj - A dictionary of properties
      */
     update(obj) {
         for (const [propertyName, propertyValue] of Object.entries(obj))
             this[`_${propertyName}`] = propertyValue;
     }
 }
-

--- a/installed-tests/fixtures/utils.js
+++ b/installed-tests/fixtures/utils.js
@@ -36,6 +36,13 @@ globalThis.HAVE_GNOME = true;
 /*
  * File Helpers
  */
+
+
+/**
+ * Find the path to the datadir via the import path.
+ *
+ * @returns {string} The absolute datadir path
+ */
 function get_datadir() {
     const thisFile = Gio.File.new_for_uri(import.meta.url);
 
@@ -45,21 +52,45 @@ function get_datadir() {
 const DATA_PATH = get_datadir();
 
 
+/**
+ * Convert a filename into a path within the datadir
+ *
+ * @param {string} filename - A filename
+ * @returns {string} An absolute path
+ */
 export function getDataPath(filename) {
     return GLib.build_filenamev([DATA_PATH, filename]);
 }
 
 
+/**
+ * Convert a filename into a URI within the datadir
+ *
+ * @param {string} filename - A filename
+ * @returns {string} An absolute-path URI
+ */
 export function getDataUri(filename) {
     return `file://${getDataPath(filename)}`;
 }
 
 
+/**
+ * Create a Gio.File object for a filename within the datadir
+ *
+ * @param {string} filename - A filename
+ * @returns {Gio.File} A File object representing the named file
+ */
 export function getDataFile(filename) {
     return Gio.File.new_for_path(getDataPath(filename));
 }
 
 
+/**
+ * Read the contents of a file
+ *
+ * @param {string} filename - The file to load
+ * @returns {string} The file's contents as a UTF-8 string
+ */
 export function loadDataContents(filename) {
     const path = getDataPath(filename);
     const bytes = GLib.file_get_contents(path)[1];
@@ -84,6 +115,12 @@ Promise.idle = function (priority = GLib.PRIORITY_DEFAULT_IDLE) {
 /*
  * Identity Helpers
  */
+
+/**
+ * Get a pseudo-random device type
+ *
+ * @returns {string} A GSConnect device type
+ */
 function getDeviceType() {
     const types = [
         'desktop',
@@ -99,8 +136,8 @@ function getDeviceType() {
 /**
  * Generate a pseudo-random device identity.
  *
- * @param {Object} params - Override parameters
- * @return {Object} A pseudo-random identity packet
+ * @param {object} params - Override parameters
+ * @returns {object} A pseudo-random identity packet
  */
 export function generateIdentity(params = {}) {
     const identity = {
@@ -130,9 +167,9 @@ export function generateIdentity(params = {}) {
 /**
  * Check if @subset is a subset of @obj.
  *
- * @param {Object} obj - The haystack to compare with
- * @param {Object} subset - The needle to search for
- * @return {boolean} %true if the object is a subset
+ * @param {object} obj - The haystack to compare with
+ * @param {object} subset - The needle to search for
+ * @returns {boolean} %true if the object is a subset
  */
 function isSubset(obj, subset) {
     for (const [key, val] of Object.entries(subset)) {
@@ -176,7 +213,7 @@ function isSubset(obj, subset) {
  * packet to handle. Note, the object must have an active jasmine spy.
  *
  * @param {string} type - A KDE Connect packet type
- * @param {Object} [body] - Packet body properties
+ * @param {object} [body] - Packet body properties
  */
 async function _awaitPacket(type, body = null) {
     while (true) {
@@ -202,7 +239,7 @@ Plugin.prototype.awaitPacket = _awaitPacket;
 /**
  * Create temporary directories used by GSConnect.
  *
- * @return {string} The root temporary directory
+ * @returns {string} The root temporary directory
  */
 function isolateDirectories() {
     const tmpdir = GLib.Dir.make_tmp('gsconnect.XXXXXX');
@@ -291,10 +328,10 @@ export class TestRig {
      * Connect the devices with `setConnected()`, pair them with `setPaired()`
      * and load their plugins with `loadPlugins()`.
      *
-     * @param {Object} [overrides] - Capability overrides
-     * @param {Object} overrides.localDevice - Local device overrides
-     * @param {Object} overrides.remoteDevice - Remote device overrides
-     * @return {Promise} A promise for the operation
+     * @param {object} [overrides] - Capability overrides
+     * @param {object} overrides.localDevice - Local device overrides
+     * @param {object} overrides.remoteDevice - Remote device overrides
+     * @returns {Promise} A promise for the operation
      */
     prepare(overrides = {}) {
         return new Promise((resolve, reject) => {

--- a/installed-tests/jasmine.js
+++ b/installed-tests/jasmine.js
@@ -4,7 +4,6 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
-// eslint-disable-next-line no-unused-vars
 export const getJasmineRequireObj = (function(jasmineGlobal) {
   var jasmineRequire;
 

--- a/installed-tests/suites/plugins/testContactsPlugin.js
+++ b/installed-tests/suites/plugins/testContactsPlugin.js
@@ -35,6 +35,11 @@ const Packets = {
 };
 
 
+/**
+ * Mocked packet handling for the test device
+ *
+ * @param {*} packet - a KDE Connect protocol packet
+ */
 function handlePacket(packet) {
     if (packet.type === 'kdeconnect.contacts.request_all_uids_timestamps') {
         this.sendPacket(Packets.uidsResponse);
@@ -145,4 +150,3 @@ describe('The contacts plugin', function () {
         expect(localPlugin._store.get_contact('valid')).toBeDefined();
     });
 });
-

--- a/installed-tests/suites/plugins/testSftpPlugin.js
+++ b/installed-tests/suites/plugins/testSftpPlugin.js
@@ -34,6 +34,11 @@ const Packets = {
 };
 
 
+/**
+ * Mocked packet handling for the test device
+ *
+ * @param {*} packet - a KDE Connect protocol packet
+ */
 function handlePacket(packet) {
     switch (packet.type) {
         case 'kdeconnect.sftp.request':
@@ -119,4 +124,3 @@ describe('The sftp plugin', function () {
         expect(localPlugin.device.get_action_enabled('unmount')).toBeFalse();
     });
 });
-

--- a/installed-tests/suites/plugins/testSmsPlugin.js
+++ b/installed-tests/suites/plugins/testSmsPlugin.js
@@ -123,6 +123,11 @@ const Packets = {
 };
 
 
+/**
+ * Mocked packet handling for the test device
+ *
+ * @param {*} packet - a KDE Connect protocol packet
+ */
 function handlePacket(packet) {
     switch (packet.type) {
         case 'kdeconnect.sms.request_conversations':
@@ -275,4 +280,3 @@ describe('The sms plugin', function () {
             expect(localPlugin.device.get_action_enabled(action)).toBeFalse();
     });
 });
-

--- a/installed-tests/suites/plugins/testSystemvolumePlugin.js
+++ b/installed-tests/suites/plugins/testSystemvolumePlugin.js
@@ -5,6 +5,11 @@
 import * as Utils from '../fixtures/utils.js';
 
 
+/**
+ * Mocked packet handling for the test device
+ *
+ * @param {*} packet - a KDE Connect protocol packet
+ */
 function handlePacket(packet) {
     switch (packet.type) {
         case 'kdeconnect.systemvolume':
@@ -129,4 +134,3 @@ describe('The systemvolume plugin', function () {
         expect(localPlugin._mixer.lookup_sink(0).muted).toBeTrue();
     });
 });
-

--- a/src/preferences/device.js
+++ b/src/preferences/device.js
@@ -60,7 +60,7 @@ export function rowSeparators(row, before) {
  *
  * @param {Gtk.ListBoxRow} row1 - The first row
  * @param {Gtk.ListBoxRow} row2 - The second row
- * @return {number} -1, 0 or 1
+ * @returns {number} -1, 0 or 1
  */
 export function titleSortFunc(row1, row2) {
     if (!row1.title || !row2.title)

--- a/src/preferences/keybindings.js
+++ b/src/preferences/keybindings.js
@@ -205,7 +205,7 @@ export const ShortcutChooserDialog = GObject.registerClass({
  * @param {string} accelerator - An accelerator
  * @param {number} [modeFlags] - Mode Flags
  * @param {number} [grabFlags] - Grab Flags
- * @param {boolean} %true if available, %false on error or unavailable
+ * @returns {boolean} %true if available, %false on error or unavailable
  */
 export async function checkAccelerator(accelerator, modeFlags = 0, grabFlags = 0) {
     try {
@@ -272,7 +272,7 @@ export async function checkAccelerator(accelerator, modeFlags = 0, grabFlags = 0
  *
  * @param {string} summary - A description of the keybinding's function
  * @param {string} accelerator - An accelerator as taken by Gtk.ShortcutLabel
- * @return {string} An accelerator or %null if it should be unset.
+ * @returns {string} An accelerator or %null if it should be unset.
  */
 export async function getAccelerator(summary, accelerator = null) {
     try {
@@ -311,4 +311,3 @@ export async function getAccelerator(summary, accelerator = null) {
         return accelerator;
     }
 }
-

--- a/src/service/backends/lan.js
+++ b/src/service/backends/lan.js
@@ -596,7 +596,7 @@ export const Channel = GObject.registerClass({
      * Authenticate a TLS connection.
      *
      * @param {Gio.TlsConnection} connection - A TLS connection
-     * @return {Promise} A promise for the operation
+     * @returns {Promise} A promise for the operation
      */
     async _authenticate(connection) {
         // Standard TLS Handshake
@@ -668,7 +668,7 @@ export const Channel = GObject.registerClass({
      * Wrap the connection in Gio.TlsClientConnection and initiate handshake
      *
      * @param {Gio.TcpConnection} connection - The unauthenticated connection
-     * @return {Gio.TlsClientConnection} The authenticated connection
+     * @returns {Gio.TlsClientConnection} The authenticated connection
      */
     _encryptClient(connection) {
         _configureSocket(connection);
@@ -684,7 +684,7 @@ export const Channel = GObject.registerClass({
      * Wrap the connection in Gio.TlsServerConnection and initiate handshake
      *
      * @param {Gio.TcpConnection} connection - The unauthenticated connection
-     * @return {Gio.TlsServerConnection} The authenticated connection
+     * @returns {Gio.TlsServerConnection} The authenticated connection
      */
     _encryptServer(connection) {
         _configureSocket(connection);

--- a/src/service/components/contacts.js
+++ b/src/service/components/contacts.js
@@ -329,7 +329,7 @@ const Store = GObject.registerClass({
      * Save a Uint8Array to file and return the path
      *
      * @param {Uint8Array} contents - An image byte array
-     * @return {string|undefined} File path or %undefined on failure
+     * @returns {string|undefined} File path or %undefined on failure
      */
     async storeAvatar(contents) {
         const md5 = GLib.compute_checksum_for_data(GLib.ChecksumType.MD5,
@@ -353,10 +353,10 @@ const Store = GObject.registerClass({
     /**
      * Query the Store for a contact by name and/or number.
      *
-     * @param {Object} query - A query object
+     * @param {object} query - A query object
      * @param {string} [query.name] - The contact's name
      * @param {string} query.number - The contact's number
-     * @return {Object} A contact object
+     * @returns {object} A contact object
      */
     query(query) {
         // First look for an existing contact by number
@@ -410,7 +410,7 @@ const Store = GObject.registerClass({
     /**
      * Add a contact, checking for validity
      *
-     * @param {Object} contact - A contact object
+     * @param {object} contact - A contact object
      * @param {boolean} write - Write to disk
      */
     add(contact, write = true) {
@@ -468,8 +468,8 @@ const Store = GObject.registerClass({
      *
      * { "555-5555": { "name": "...", "numbers": [], ... } }
      *
-     * @param {Object[]} addresses - A list of address objects
-     * @return {Object} A dictionary of phone numbers and contacts
+     * @param {object[]} addresses - A list of address objects
+     * @returns {object} A dictionary of phone numbers and contacts
      */
     lookupAddresses(addresses) {
         const contacts = {};
@@ -502,7 +502,7 @@ const Store = GObject.registerClass({
     /**
      * Update the contact store from a dictionary of our custom contact objects.
      *
-     * @param {Object} json - an Object of contact Objects
+     * @param {object} json - an Object of contact Objects
      */
     async update(json = {}) {
         try {

--- a/src/service/components/index.js
+++ b/src/service/components/index.js
@@ -41,7 +41,7 @@ const Default = new Map();
  * followed by a call to `release()`.
  *
  * @param {string} name - The module name
- * @return {*} The default instance of a component
+ * @returns {*} The default instance of a component
  */
 export function acquire(name) {
     if (functionOverrides.acquire)
@@ -78,7 +78,7 @@ export function acquire(name) {
  * holder, the component will be freed.
  *
  * @param {string} name - The module name
- * @return {null} A %null value, useful for overriding a traced variable
+ * @returns {null} A %null value, useful for overriding a traced variable
  */
 export function release(name) {
     if (functionOverrides.release)
@@ -99,4 +99,3 @@ export function release(name) {
 
     return null;
 }
-

--- a/src/service/components/mpris.js
+++ b/src/service/components/mpris.js
@@ -472,6 +472,10 @@ const PlayerProxy = GObject.registerClass({
     GTypeName: 'GSConnectMPRISPlayer',
 }, class PlayerProxy extends Player {
 
+    /**
+     * @constructs GSConnectMPRISPlayer
+     * @param {string} name - The name of the player
+     */
     _init(name) {
         super._init();
 
@@ -914,7 +918,7 @@ const Manager = GObject.registerClass({
      * Check for a player by its Identity.
      *
      * @param {string} identity - A player name
-     * @return {boolean} %true if the player was found
+     * @returns {boolean} %true if the player was found
      */
     hasPlayer(identity) {
         for (const player of this._players.values()) {
@@ -929,7 +933,7 @@ const Manager = GObject.registerClass({
      * Get a player by its Identity.
      *
      * @param {string} identity - A player name
-     * @return {GSConnectMPRISPlayer|null} A player or %null
+     * @returns {GSConnectMPRISPlayer|null} A player or %null
      */
     getPlayer(identity) {
         for (const player of this._players.values()) {
@@ -943,7 +947,7 @@ const Manager = GObject.registerClass({
     /**
      * Get a list of player identities.
      *
-     * @return {string[]} A list of player identities
+     * @returns {string[]} A list of player identities
      */
     getIdentities() {
         const identities = [];

--- a/src/service/components/notification.js
+++ b/src/service/components/notification.js
@@ -144,7 +144,7 @@ const Listener = GObject.registerClass({
      *
      * @param {string} sender - A DBus unique name (eg. :1.2282)
      * @param {string} appName - @appName passed to Notify() (Optional)
-     * @return {string} A well-known name or %null
+     * @returns {string} A well-known name or %null
      */
     async _getAppId(sender, appName) {
         try {
@@ -189,7 +189,7 @@ const Listener = GObject.registerClass({
      *
      * @param {string} sender - A DBus unique name
      * @param {string} [appName] - `appName` supplied by Notify()
-     * @return {string} A well-known name or %null
+     * @returns {string} A well-known name or %null
      */
     async _getAppName(sender, appName = null) {
         // Check the cache first
@@ -261,7 +261,7 @@ const Listener = GObject.registerClass({
     /**
      * Export interfaces for proxying notifications and become a monitor
      *
-     * @return {Promise} A promise for the operation
+     * @returns {Promise} A promise for the operation
      */
     _monitorConnection() {
         // libnotify Interface

--- a/src/service/core.js
+++ b/src/service/core.js
@@ -12,7 +12,7 @@ import plugins from './plugins/index.js';
 /**
  * Get the local device type.
  *
- * @return {string} A device type string
+ * @returns {string} A device type string
  */
 export function _getDeviceType() {
     try {
@@ -69,8 +69,8 @@ export class Packet {
     /**
      * Deserialize and return a new Packet from an Object or string.
      *
-     * @param {Object|string} data - A string or dictionary to deserialize
-     * @return {Core.Packet} A new packet object
+     * @param {object|string} data - A string or dictionary to deserialize
+     * @returns {Packet} A new packet object
      */
     static deserialize(data) {
         return new Packet(data);
@@ -80,7 +80,7 @@ export class Packet {
      * Serialize the packet as a single line with a terminating new-line (`\n`)
      * character, ready to be written to a channel.
      *
-     * @return {string} A serialized packet
+     * @returns {string} A serialized packet
      */
     serialize() {
         this.id = Date.now();
@@ -90,7 +90,7 @@ export class Packet {
     /**
      * Update the packet from a dictionary or string of JSON
      *
-     * @param {Object|string} data - Source data
+     * @param {object|string} data - Source data
      */
     update(data) {
         try {
@@ -106,7 +106,7 @@ export class Packet {
     /**
      * Check if the packet has a payload.
      *
-     * @return {boolean} %true if @packet has a payload
+     * @returns {boolean} %true if @packet has a payload
      */
     hasPayload() {
         if (!this.hasOwnProperty('payloadSize'))
@@ -219,7 +219,7 @@ export const Channel = GObject.registerClass({
      * Read a packet.
      *
      * @param {Gio.Cancellable} [cancellable] - A cancellable
-     * @return {Promise<Core.Packet>} The packet
+     * @returns {Promise<Packet>} The packet
      */
     async readPacket(cancellable = null) {
         if (cancellable === null)
@@ -247,9 +247,9 @@ export const Channel = GObject.registerClass({
     /**
      * Send a packet.
      *
-     * @param {Core.Packet} packet - The packet to send
+     * @param {Packet} packet - The packet to send
      * @param {Gio.Cancellable} [cancellable] - A cancellable
-     * @return {Promise<boolean>} %true if successful
+     * @returns {Promise<boolean>} %true if successful
      */
     sendPacket(packet, cancellable = null) {
         if (cancellable === null)
@@ -262,7 +262,7 @@ export const Channel = GObject.registerClass({
     /**
      * Reject a transfer.
      *
-     * @param {Core.Packet} packet - A packet with payload info
+     * @param {Packet} packet - A packet with payload info
      */
     rejectTransfer(packet) {
         throw new GObject.NotImplementedError();
@@ -272,7 +272,7 @@ export const Channel = GObject.registerClass({
      * Download a payload from a device. Typically implementations will override
      * this with an async function.
      *
-     * @param {Core.Packet} packet - A packet
+     * @param {Packet} packet - A packet
      * @param {Gio.OutputStream} target - The target stream
      * @param {Gio.Cancellable} [cancellable] - A cancellable for the upload
      */
@@ -285,7 +285,7 @@ export const Channel = GObject.registerClass({
      * Upload a payload to a device. Typically implementations will override
      * this with an async function.
      *
-     * @param {Core.Packet} packet - The packet describing the transfer
+     * @param {Packet} packet - The packet describing the transfer
      * @param {Gio.InputStream} source - The source stream
      * @param {number} size - The payload size
      * @param {Gio.Cancellable} [cancellable] - A cancellable for the upload
@@ -429,7 +429,7 @@ export const ChannelService = GObject.registerClass({
     /**
      * Emit Core.ChannelService::channel
      *
-     * @param {Core.Channel} channel - The new channel
+     * @param {Channel} channel - The new channel
      */
     channel(channel) {
         if (!this.emit('channel', channel))
@@ -542,7 +542,7 @@ export const Transfer = GObject.registerClass({
     /**
      * Ensure there is a stream for the transfer item.
      *
-     * @param {Object} item - A transfer item
+     * @param {object} item - A transfer item
      * @param {Gio.Cancellable} [cancellable] - A cancellable
      */
     async _ensureStream(item, cancellable = null) {
@@ -583,7 +583,7 @@ export const Transfer = GObject.registerClass({
     /**
      * Add a file to the transfer.
      *
-     * @param {Core.Packet} packet - A packet
+     * @param {Packet} packet - A packet
      * @param {Gio.File} file - A file to transfer
      */
     addFile(packet, file) {
@@ -600,7 +600,7 @@ export const Transfer = GObject.registerClass({
     /**
      * Add a filepath to the transfer.
      *
-     * @param {Core.Packet} packet - A packet
+     * @param {Packet} packet - A packet
      * @param {string} path - A filepath to transfer
      */
     addPath(packet, path) {
@@ -617,7 +617,7 @@ export const Transfer = GObject.registerClass({
     /**
      * Add a stream to the transfer.
      *
-     * @param {Core.Packet} packet - A packet
+     * @param {Packet} packet - A packet
      * @param {Gio.InputStream|Gio.OutputStream} stream - A stream to transfer
      * @param {number} [size] - Payload size
      */

--- a/src/service/daemon.js
+++ b/src/service/daemon.js
@@ -154,7 +154,7 @@ const Service = GObject.registerClass({
     /**
      * Report a service-level error
      *
-     * @param {Object} error - An Error or object with name, message and stack
+     * @param {object} error - An Error or object with name, message and stack
      */
     notify_error(error) {
         try {
@@ -699,4 +699,3 @@ const Service = GObject.registerClass({
 });
 
 await (new Service()).runAsync([system.programInvocationName].concat(ARGV));
-

--- a/src/service/device.js
+++ b/src/service/device.js
@@ -750,10 +750,8 @@ const Device = GObject.registerClass({
      * @returns {void}
      */
     rejectTransfer(packet) {
-        if (!packet || !packet.hasPayload())
-            return;
-
-        return this.channel.rejectTransfer(packet);
+        if (packet?.hasPayload())
+            return this.channel.rejectTransfer(packet);
     }
 
     openPath(action, parameter) {

--- a/src/service/device.js
+++ b/src/service/device.js
@@ -384,7 +384,7 @@ const Device = GObject.registerClass({
      *
      * @param {string[]} args - process arguments
      * @param {Gio.Cancellable} [cancellable] - optional cancellable
-     * @return {Gio.Subprocess} The subprocess
+     * @returns {Gio.Subprocess} The subprocess
      */
     launchProcess(args, cancellable = null) {
         if (this._launcher === undefined) {
@@ -418,7 +418,7 @@ const Device = GObject.registerClass({
      * Handle a packet and pass it to the appropriate plugin.
      *
      * @param {Core.Packet} packet - The incoming packet object
-     * @return {undefined} no return value
+     * @returns {undefined} no return value
      */
     handlePacket(packet) {
         try {
@@ -443,7 +443,7 @@ const Device = GObject.registerClass({
     /**
      * Send a packet to the device.
      *
-     * @param {Object} packet - An object of packet data...
+     * @param {object} packet - An object of packet data...
      */
     async sendPacket(packet) {
         try {
@@ -524,7 +524,7 @@ const Device = GObject.registerClass({
      * device menu.
      *
      * @param {string} actionName - An action name with scope (eg. device.foo)
-     * @return {number} An 0-based index or -1 if not found
+     * @returns {number} An 0-based index or -1 if not found
      */
     getMenuAction(actionName) {
         for (let i = 0, len = this.menu.get_n_items(); i < len; i++) {
@@ -546,7 +546,7 @@ const Device = GObject.registerClass({
      *
      * @param {Gio.MenuItem} menuItem - A GMenuItem
      * @param {number} [index] - The position to place the item
-     * @return {number} The position the item was placed
+     * @returns {number} The position the item was placed
      */
     addMenuItem(menuItem, index = -1) {
         try {
@@ -570,7 +570,7 @@ const Device = GObject.registerClass({
      * @param {number} [index] - The position to place the item
      * @param {string} label - A label for the item
      * @param {string} icon_name - A themed icon name for the item
-     * @return {number} The position the item was placed
+     * @returns {number} The position the item was placed
      */
     addMenuAction(action, index = -1, label, icon_name) {
         try {
@@ -600,7 +600,7 @@ const Device = GObject.registerClass({
      * Remove a GAction from the top level of the device menu by action name
      *
      * @param {string} actionName - A GAction name, including scope
-     * @return {number} The position the item was removed from or -1
+     * @returns {number} The position the item was removed from or -1
      */
     removeMenuAction(actionName) {
         try {
@@ -631,7 +631,7 @@ const Device = GObject.registerClass({
     /**
      * Show a device notification.
      *
-     * @param {Object} params - A dictionary of notification parameters
+     * @param {object} params - A dictionary of notification parameters
      * @param {number} [params.id] - A UNIX epoch timestamp (ms)
      * @param {string} [params.title] - A title
      * @param {string} [params.body] - A body
@@ -728,7 +728,7 @@ const Device = GObject.registerClass({
     /**
      * Create a transfer object.
      *
-     * @return {Core.Transfer} A new transfer
+     * @returns {Core.Transfer} A new transfer
      */
     createTransfer() {
         const transfer = new Core.Transfer({device: this});
@@ -747,7 +747,7 @@ const Device = GObject.registerClass({
      * Reject the transfer payload described by @packet.
      *
      * @param {Core.Packet} packet - A packet
-     * @return {Promise} A promise for the operation
+     * @returns {void}
      */
     rejectTransfer(packet) {
         if (!packet || !packet.hasPayload())

--- a/src/service/init.js
+++ b/src/service/init.js
@@ -163,7 +163,7 @@ if (!globalThis.HAVE_GNOME) {
  * A simple (for now) pre-comparison sanitizer for phone numbers
  * See: https://github.com/KDE/kdeconnect-kde/blob/master/smsapp/conversationlistmodel.cpp#L200-L210
  *
- * @return {string} Return the string stripped of leading 0, and ' ()-+'
+ * @returns {string} Return the string stripped of leading 0, and ' ()-+'
  */
 String.prototype.toPhoneNumber = function () {
     const strippedNumber = this.replace(/^0*|[ ()+-]/g, '');
@@ -179,7 +179,7 @@ String.prototype.toPhoneNumber = function () {
  * A simple equality check for phone numbers based on `toPhoneNumber()`
  *
  * @param {string} number - A phone number string to compare
- * @return {boolean} If `this` and @number are equivalent phone numbers
+ * @returns {boolean} If `this` and @number are equivalent phone numbers
  */
 String.prototype.equalsPhoneNumber = function (number) {
     const a = this.toPhoneNumber();
@@ -227,7 +227,7 @@ Gio.File.rm_rf = function (file) {
  * Extend GLib.Variant with a static method to recursively pack a variant
  *
  * @param {*} [obj] - May be a GLib.Variant, Array, standard Object or literal.
- * @return {GLib.Variant} The resulting GVariant
+ * @returns {GLib.Variant} The resulting GVariant
  */
 function _full_pack(obj) {
     let packed;
@@ -283,7 +283,7 @@ GLib.Variant.full_pack = _full_pack;
  * Extend GLib.Variant with a method to recursively deepUnpack() a variant
  *
  * @param {*} [obj] - May be a GLib.Variant, Array, standard Object or literal.
- * @return {*} The resulting object
+ * @returns {*} The resulting object
  */
 function _full_unpack(obj) {
     obj = (obj === undefined) ? this : obj;
@@ -326,8 +326,8 @@ GLib.Variant.prototype.full_unpack = _full_unpack;
 
 
 /**
- * Creates a GTlsCertificate from the PEM-encoded data in @cert_path and
- * @key_path. If either are missing a new pair will be generated.
+ * Creates a GTlsCertificate from the PEM-encoded data in %cert_path and
+ * %key_path. If either are missing a new pair will be generated.
  *
  * Additionally, the private key will be added using ssh-add to allow sftp
  * connections using Gio.
@@ -337,7 +337,7 @@ GLib.Variant.prototype.full_unpack = _full_unpack;
  * @param {string} certPath - Absolute path to a x509 certificate in PEM format
  * @param {string} keyPath - Absolute path to a private key in PEM format
  * @param {string} commonName - A unique common name for the certificate
- * @return {Gio.TlsCertificate} A TLS certificate
+ * @returns {Gio.TlsCertificate} A TLS certificate
  */
 Gio.TlsCertificate.new_for_paths = function (certPath, keyPath, commonName = null) {
     // Check if the certificate/key pair already exists
@@ -396,7 +396,7 @@ Object.defineProperties(Gio.TlsCertificate.prototype, {
     /**
      * Get just the pubkey as a DER ByteArray of a certificate.
      *
-     * @return {GLib.Bytes} The pubkey as DER of the certificate.
+     * @returns {GLib.Bytes} The pubkey as DER of the certificate.
      */
     'pubkey_der': {
         value: function () {

--- a/src/service/manager.js
+++ b/src/service/manager.js
@@ -7,6 +7,7 @@ import GLib from 'gi://GLib';
 import GObject from 'gi://GObject';
 
 import Config from '../config.js';
+import * as Core from './core.js';
 import * as DBus from './utils/dbus.js';
 import Device from './device.js';
 
@@ -382,7 +383,7 @@ const Manager = GObject.registerClass({
      * of known devices if it doesn't exist.
      *
      * @param {Core.Packet} packet - An identity packet for the device
-     * @return {Device} A device object
+     * @returns {Device} A device object
      */
     _ensureDevice(packet) {
         let device = this.devices.get(packet.body.deviceId);
@@ -438,7 +439,7 @@ const Manager = GObject.registerClass({
      * A GSourceFunc that tries to reconnect to each paired device, while
      * pruning unpaired devices that have disconnected.
      *
-     * @return {boolean} Always %true
+     * @returns {boolean} Always %true
      */
     _reconnect() {
         for (const [id, device] of this.devices) {

--- a/src/service/plugin.js
+++ b/src/service/plugin.js
@@ -7,6 +7,7 @@ import GLib from 'gi://GLib';
 import GObject from 'gi://GObject';
 
 import Config from '../config.js';
+import * as Core from './core.js';
 import plugins from './plugins/index.js';
 
 
@@ -248,4 +249,3 @@ const Plugin = GObject.registerClass({
 });
 
 export default Plugin;
-

--- a/src/service/plugins/battery.js
+++ b/src/service/plugins/battery.js
@@ -7,6 +7,7 @@ import GLib from 'gi://GLib';
 import GObject from 'gi://GObject';
 
 import * as Components from '../components/index.js';
+import * as Core from './core.js';
 import Plugin from '../plugin.js';
 
 

--- a/src/service/plugins/battery.js
+++ b/src/service/plugins/battery.js
@@ -7,7 +7,7 @@ import GLib from 'gi://GLib';
 import GObject from 'gi://GObject';
 
 import * as Components from '../components/index.js';
-import * as Core from './core.js';
+import * as Core from '../core.js';
 import Plugin from '../plugin.js';
 
 

--- a/src/service/plugins/connectivity_report.js
+++ b/src/service/plugins/connectivity_report.js
@@ -6,6 +6,7 @@ import Gio from 'gi://Gio';
 import GLib from 'gi://GLib';
 import GObject from 'gi://GObject';
 
+import * as Core from './core.js';
 import Plugin from '../plugin.js';
 
 

--- a/src/service/plugins/connectivity_report.js
+++ b/src/service/plugins/connectivity_report.js
@@ -6,7 +6,7 @@ import Gio from 'gi://Gio';
 import GLib from 'gi://GLib';
 import GObject from 'gi://GObject';
 
-import * as Core from './core.js';
+import * as Core from '../core.js';
 import Plugin from '../plugin.js';
 
 

--- a/src/service/plugins/contacts.js
+++ b/src/service/plugins/contacts.js
@@ -7,6 +7,7 @@ import GObject from 'gi://GObject';
 
 import Plugin from '../plugin.js';
 import Contacts from '../components/contacts.js';
+import * as Core from './core.js';
 
 /*
  * We prefer libebook's vCard parser if it's available
@@ -150,7 +151,7 @@ const ContactsPlugin = GObject.registerClass({
      * See: https://github.com/mathiasbynens/quoted-printable/blob/master/src/quoted-printable.js
      *
      * @param {string} input - The QUOTED-PRINTABLE string
-     * @return {string} The decoded string
+     * @returns {string} The decoded string
      */
     _decodeQuotedPrintable(input) {
         return input
@@ -171,7 +172,7 @@ const ContactsPlugin = GObject.registerClass({
      * See: https://github.com/kvz/locutus/blob/master/src/php/xml/utf8_decode.js
      *
      * @param {string} input - The UTF-8 string
-     * @return {string} The decoded string
+     * @returns {string} The decoded string
      */
     _decodeUTF8(input) {
         try {
@@ -233,7 +234,7 @@ const ContactsPlugin = GObject.registerClass({
      * See: http://jsfiddle.net/ARTsinn/P2t2P/
      *
      * @param {string} vcard_data - The raw VCard data
-     * @return {Object} dictionary of vCard data
+     * @returns {object} dictionary of vCard data
      */
     _parseVCard21(vcard_data) {
         // vcard skeleton

--- a/src/service/plugins/contacts.js
+++ b/src/service/plugins/contacts.js
@@ -7,7 +7,7 @@ import GObject from 'gi://GObject';
 
 import Plugin from '../plugin.js';
 import Contacts from '../components/contacts.js';
-import * as Core from './core.js';
+import * as Core from '../core.js';
 
 /*
  * We prefer libebook's vCard parser if it's available

--- a/src/service/plugins/mousepad.js
+++ b/src/service/plugins/mousepad.js
@@ -183,7 +183,7 @@ const MousepadPlugin = GObject.registerClass({
     /**
      * Handle a input event.
      *
-     * @param {Object} input - The body of a `kdeconnect.mousepad.request`
+     * @param {object} input - The body of a `kdeconnect.mousepad.request`
      */
     _handleInput(input) {
         if (!this.settings.get_boolean('share-control'))
@@ -285,7 +285,7 @@ const MousepadPlugin = GObject.registerClass({
     /**
      * Handle an echo/ACK of a event we sent, displaying it the dialog entry.
      *
-     * @param {Object} input - The body of a `kdeconnect.mousepad.echo`
+     * @param {object} input - The body of a `kdeconnect.mousepad.echo`
      */
     _handleEcho(input) {
         if (!this._dialog || !this._dialog.visible)
@@ -308,7 +308,7 @@ const MousepadPlugin = GObject.registerClass({
      * Handle a state change from the remote keyboard. This is an indication
      * that the remote keyboard is ready to accept input.
      *
-     * @param {Object} packet - A `kdeconnect.mousepad.keyboardstate` packet
+     * @param {object} packet - A `kdeconnect.mousepad.keyboardstate` packet
      */
     _handleState(packet) {
         this._state = !!packet.body.state;
@@ -318,7 +318,7 @@ const MousepadPlugin = GObject.registerClass({
     /**
      * Send an echo/ACK of @input, if requested
      *
-     * @param {Object} input - The body of a 'kdeconnect.mousepad.request'
+     * @param {object} input - The body of a 'kdeconnect.mousepad.request'
      */
     _sendEcho(input) {
         if (!input.sendAck)
@@ -335,8 +335,6 @@ const MousepadPlugin = GObject.registerClass({
 
     /**
      * Send the local keyboard state
-     *
-     * @param {boolean} state - Whether we're ready to accept input
      */
     _sendState() {
         this.device.sendPacket({

--- a/src/service/plugins/mpris.js
+++ b/src/service/plugins/mpris.js
@@ -8,7 +8,7 @@ import GObject from 'gi://GObject';
 
 import * as Components from '../components/index.js';
 import Config from '../../config.js';
-import * as Core from './core.js';
+import * as Core from '../core.js';
 import * as DBus from '../utils/dbus.js';
 import  {Player} from '../components/mpris.js';
 import Plugin from '../plugin.js';

--- a/src/service/plugins/mpris.js
+++ b/src/service/plugins/mpris.js
@@ -8,6 +8,7 @@ import GObject from 'gi://GObject';
 
 import * as Components from '../components/index.js';
 import Config from '../../config.js';
+import * as Core from './core.js';
 import * as DBus from '../utils/dbus.js';
 import  {Player} from '../components/mpris.js';
 import Plugin from '../plugin.js';
@@ -144,7 +145,7 @@ const MPRISPlugin = GObject.registerClass({
     /**
      * Handle an update for a remote player.
      *
-     * @param {Object} packet - A `kdeconnect.mpris` packet
+     * @param {object} packet - A `kdeconnect.mpris` packet
      */
     _handlePlayerUpdate(packet) {
         const player = this._players.get(packet.body.player);
@@ -174,7 +175,7 @@ const MPRISPlugin = GObject.registerClass({
      * Handle a request for player information or action.
      *
      * @param {Core.Packet} packet - a `kdeconnect.mpris.request`
-     * @return {undefined} no return value
+     * @returns {undefined} no return value
      */
     _handleRequest(packet) {
         // A request for the list of players

--- a/src/service/plugins/notification.js
+++ b/src/service/plugins/notification.js
@@ -8,7 +8,7 @@ import GObject from 'gi://GObject';
 import Gtk from 'gi://Gtk';
 
 import * as Components from '../components/index.js';
-import * as Core from './core.js';
+import * as Core from '../core.js';
 import Config from '../../config.js';
 import Plugin from '../plugin.js';
 import ReplyDialog from '../ui/notification.js';

--- a/src/service/plugins/notification.js
+++ b/src/service/plugins/notification.js
@@ -8,6 +8,7 @@ import GObject from 'gi://GObject';
 import Gtk from 'gi://Gtk';
 
 import * as Components from '../components/index.js';
+import * as Core from './core.js';
 import Config from '../../config.js';
 import Plugin from '../plugin.js';
 import ReplyDialog from '../ui/notification.js';
@@ -103,7 +104,7 @@ const SMS_APPS = [
  * Try to determine if an notification is from an SMS app
  *
  * @param {Core.Packet} packet - A `kdeconnect.notification`
- * @return {boolean} Whether the notification is from an SMS app
+ * @returns {boolean} Whether the notification is from an SMS app
  */
 function _isSmsNotification(packet) {
     const id = packet.body.id;
@@ -123,8 +124,8 @@ function _isSmsNotification(packet) {
 /**
  * Remove a local libnotify or Gtk notification.
  *
- * @param {String|Number} id - Gtk (string) or libnotify id (uint32)
- * @param {String|null} application - Application Id if Gtk or null
+ * @param {string | number} id - Gtk (string) or libnotify id (uint32)
+ * @param {string | null} application - Application Id if Gtk or null
  */
 function _removeNotification(id, application = null) {
     let name, path, method, variant;
@@ -416,7 +417,7 @@ const NotificationPlugin = GObject.registerClass({
      *
      * @param {Core.Packet} packet - A `kdeconnect.notification`
      * @param {Gio.Icon|string|null} icon - An icon or %null
-     * @return {Promise} A promise for the operation
+     * @returns {Promise} A promise for the operation
      */
     _uploadIcon(packet, icon = null) {
         // Normalize strings into GIcons
@@ -438,7 +439,7 @@ const NotificationPlugin = GObject.registerClass({
     /**
      * Send a local notification to the remote device.
      *
-     * @param {Object} notif - A dictionary of notification parameters
+     * @param {object} notif - A dictionary of notification parameters
      * @param {string} notif.appName - The notifying application
      * @param {string} notif.id - The notification ID
      * @param {string} notif.title - The notification title
@@ -631,7 +632,7 @@ const NotificationPlugin = GObject.registerClass({
      *
      * @param {string} uuid - The requestReplyId for the repliable notification
      * @param {string} message - The message to reply with
-     * @param {Object} notification - The original notification packet
+     * @param {object} notification - The original notification packet
      */
     replyNotification(uuid, message, notification) {
         // If this happens for some reason, things will explode

--- a/src/service/plugins/runcommand.js
+++ b/src/service/plugins/runcommand.js
@@ -150,7 +150,7 @@ const RunCommandPlugin = GObject.registerClass({
      * Parse the response to a request for the remote command list. Remove the
      * command menu if there are no commands, otherwise amend the menu.
      *
-     * @param {string|Object[]} commandList - A list of remote commands
+     * @param {string | object[]} commandList - A list of remote commands
      */
     _handleCommandList(commandList) {
         // See: https://github.com/GSConnect/gnome-shell-extension-gsconnect/issues/1051

--- a/src/service/plugins/sftp.js
+++ b/src/service/plugins/sftp.js
@@ -7,6 +7,7 @@ import GLib from 'gi://GLib';
 import GObject from 'gi://GObject';
 
 import Config from '../../config.js';
+import * as Core from './core.js';
 import Plugin from '../plugin.js';
 
 
@@ -246,7 +247,7 @@ const SFTPPlugin = GObject.registerClass({
      * Add GSConnect's private key identity to the authentication agent so our
      * identity can be verified by Android during private key authentication.
      *
-     * @return {Promise} A promise for the operation
+     * @returns {Promise} A promise for the operation
      */
     async _addPrivateKey() {
         const ssh_add = this._launcher.spawnv([

--- a/src/service/plugins/sftp.js
+++ b/src/service/plugins/sftp.js
@@ -7,7 +7,7 @@ import GLib from 'gi://GLib';
 import GObject from 'gi://GObject';
 
 import Config from '../../config.js';
-import * as Core from './core.js';
+import * as Core from '../core.js';
 import Plugin from '../plugin.js';
 
 

--- a/src/service/plugins/sms.js
+++ b/src/service/plugins/sms.js
@@ -206,7 +206,7 @@ const SMSPlugin = GObject.registerClass({
     /**
      * Handle a digest of threads.
      *
-     * @param {Object[]} messages - A list of message objects
+     * @param {object[]} messages - A list of message objects
      * @param {string[]} thread_ids - A list of thread IDs as strings
      */
     _handleDigest(messages, thread_ids) {
@@ -244,7 +244,7 @@ const SMSPlugin = GObject.registerClass({
     /**
      * Handle a new single message
      *
-     * @param {Object} message - A message object
+     * @param {object} message - A message object
      */
     _handleMessage(message) {
         let conversation = null;
@@ -261,7 +261,7 @@ const SMSPlugin = GObject.registerClass({
     /**
      * Parse a conversation (thread of messages) and sort them
      *
-     * @param {Object[]} thread - A list of sms message objects from a thread
+     * @param {object[]} thread - A list of sms message objects from a thread
      */
     _handleThread(thread) {
         // If there are no addresses this will cause major problems...
@@ -300,7 +300,7 @@ const SMSPlugin = GObject.registerClass({
     /**
      * Handle a response to telephony.request_conversation(s)
      *
-     * @param {Object[]} messages - A list of sms message objects
+     * @param {object[]} messages - A list of sms message objects
      */
     _handleMessages(messages) {
         try {
@@ -394,7 +394,7 @@ const SMSPlugin = GObject.registerClass({
     /**
      * Send a message
      *
-     * @param {Object[]} addresses - A list of address objects
+     * @param {object[]} addresses - A list of address objects
      * @param {string} messageBody - The message text
      * @param {number} [event] - An event bitmask
      * @param {boolean} [forceSms] - Whether to force SMS
@@ -508,8 +508,8 @@ const SMSPlugin = GObject.registerClass({
     /**
      * Try to find a thread_id in @smsPlugin for @addresses.
      *
-     * @param {Object[]} addresses - a list of address objects
-     * @return {string|null} a thread ID
+     * @param {object[]} addresses - a list of address objects
+     * @returns {string|null} a thread ID
      */
     getThreadIdForAddresses(addresses = []) {
         const threads = Object.values(this.threads);

--- a/src/service/plugins/systemvolume.js
+++ b/src/service/plugins/systemvolume.js
@@ -2,13 +2,25 @@
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+import GIRepository from 'gi://GIRepository';
+import GLib from 'gi://GLib';
 import GObject from 'gi://GObject';
 
 import * as Components from '../components/index.js';
 import Config from '../../config.js';
 import * as Core from '../core.js';
 import Plugin from '../plugin.js';
-import {Gvc} from '../components/pulseaudio.js';
+
+
+let Gvc = null;
+try {
+    // Add gnome-shell's typelib dir to the search path
+    const typelibDir = GLib.build_filenamev([Config.GNOME_SHELL_LIBDIR, 'gnome-shell']);
+    GIRepository.Repository.prepend_search_path(typelibDir);
+    GIRepository.Repository.prepend_library_path(typelibDir);
+
+    Gvc = (await import('gi://Gvc')).default;
+} catch {}
 
 
 export const Metadata = {

--- a/src/service/plugins/systemvolume.js
+++ b/src/service/plugins/systemvolume.js
@@ -6,7 +6,7 @@ import GObject from 'gi://GObject';
 
 import * as Components from '../components/index.js';
 import Config from '../../config.js';
-import * as Core from './core.js';
+import * as Core from '../core.js';
 import Plugin from '../plugin.js';
 import {Gvc} from '../components/pulseaudio.js';
 

--- a/src/service/plugins/systemvolume.js
+++ b/src/service/plugins/systemvolume.js
@@ -6,7 +6,9 @@ import GObject from 'gi://GObject';
 
 import * as Components from '../components/index.js';
 import Config from '../../config.js';
+import * as Core from './core.js';
 import Plugin from '../plugin.js';
+import {Gvc} from '../components/pulseaudio.js';
 
 
 export const Metadata = {
@@ -121,7 +123,7 @@ const SystemVolumePlugin = GObject.registerClass({
      * Update the cache for @stream
      *
      * @param {Gvc.MixerStream} stream - The stream to cache
-     * @return {Object} The updated cache object
+     * @returns {object} The updated cache object
      */
     _updateCache(stream) {
         const state = {

--- a/src/service/plugins/telephony.js
+++ b/src/service/plugins/telephony.js
@@ -8,6 +8,7 @@ import GLib from 'gi://GLib';
 import GObject from 'gi://GObject';
 
 import * as Components from '../components/index.js';
+import * as Core from '../core.js';
 import Plugin from '../plugin.js';
 
 
@@ -114,7 +115,7 @@ const TelephonyPlugin = GObject.registerClass({
      * Load a Gdk.Pixbuf from base64 encoded data
      *
      * @param {string} data - Base64 encoded JPEG data
-     * @return {Gdk.Pixbuf|null} A contact photo
+     * @returns {GdkPixbuf.Pixbuf|null} A contact photo
      */
     _getThumbnailPixbuf(data) {
         const loader = new GdkPixbuf.PixbufLoader();

--- a/src/service/ui/contacts.js
+++ b/src/service/ui/contacts.js
@@ -16,7 +16,7 @@ import system from 'system';
  *
  * @param {*} [salt] - If not %null, will be used as salt for generating a color
  * @param {number} alpha - A value in the [0...1] range for the alpha channel
- * @return {Gdk.RGBA} A new Gdk.RGBA object generated from the input
+ * @returns {Gdk.RGBA} A new Gdk.RGBA object generated from the input
  */
 function randomRGBA(salt = null, alpha = 1.0) {
     let red, green, blue;
@@ -41,7 +41,7 @@ function randomRGBA(salt = null, alpha = 1.0) {
  * See: https://www.w3.org/TR/2008/REC-WCAG20-20081211/#relativeluminancedef
  *
  * @param {Gdk.RGBA} rgba - A GdkRGBA object
- * @return {number} The relative luminance of the color
+ * @returns {number} The relative luminance of the color
  */
 function relativeLuminance(rgba) {
     const {red, green, blue} = rgba;
@@ -59,7 +59,7 @@ function relativeLuminance(rgba) {
  * See: https://www.w3.org/TR/2008/REC-WCAG20-20081211/#contrast-ratiodef
  *
  * @param {Gdk.RGBA} rgba - A GdkRGBA object for the background color
- * @return {Gdk.RGBA} A GdkRGBA object for the foreground color
+ * @returns {Gdk.RGBA} A GdkRGBA object for the foreground color
  */
 function getFgRGBA(rgba) {
     const bgLuminance = relativeLuminance(rgba);
@@ -78,7 +78,7 @@ function getFgRGBA(rgba) {
  * @param {string} path - A local file path
  * @param {number} size - Size in pixels
  * @param {scale} [scale] - Scale factor for the size
- * @return {Gdk.Pixbuf} A pixbuf
+ * @returns {Gdk.Pixbuf} A pixbuf
  */
 function getPixbufForPath(path, size, scale = 1.0) {
     let data, loader;
@@ -107,6 +107,15 @@ function getPixbufForPath(path, size, scale = 1.0) {
     return pixbuf.scale_simple(size, size, GdkPixbuf.InterpType.HYPER);
 }
 
+/**
+ * Retrieve the GdkPixbuf for a named icon
+ *
+ * @param {string} name - The icon name to load
+ * @param {number} size - The pixel size requested
+ * @param {number} scale - The scale multiplier
+ * @param {string} bgColor - The background color the icon will be used against
+ * @returns {GdkPixbuf.pixbuf|null} The icon image
+ */
 function getPixbufForIcon(name, size, scale, bgColor) {
     const color = getFgRGBA(bgColor);
     const theme = Gtk.IconTheme.get_default();
@@ -126,7 +135,7 @@ function getPixbufForIcon(name, size, scale, bgColor) {
  * See: http://www.ietf.org/rfc/rfc2426.txt
  *
  * @param {string} type - An RFC2426 phone number type
- * @return {string} A localized string like 'Mobile'
+ * @returns {string} A localized string like 'Mobile'
  */
 function getNumberTypeLabel(type) {
     if (type.includes('fax'))
@@ -152,9 +161,9 @@ function getNumberTypeLabel(type) {
 /**
  * Get a display number from @contact for @address.
  *
- * @param {Object} contact - A contact object
+ * @param {object} contact - A contact object
  * @param {string} address - A phone number
- * @return {string} A (possibly) better display number for the address
+ * @returns {string} A (possibly) better display number for the address
  */
 export function getDisplayNumber(contact, address) {
     const number = address.toPhoneNumber();
@@ -623,7 +632,7 @@ export const ContactChooser = GObject.registerClass({
     /**
      * Get a dictionary of number-contact pairs for each selected phone number.
      *
-     * @return {Object[]} A dictionary of contacts
+     * @returns {object[]} A dictionary of contacts
      */
     getSelected() {
         try {
@@ -639,4 +648,3 @@ export const ContactChooser = GObject.registerClass({
         }
     }
 });
-

--- a/src/service/ui/messaging.js
+++ b/src/service/ui/messaging.js
@@ -92,7 +92,7 @@ const _cFormat = new Intl.DateTimeFormat('default', {
  * Return a human-readable timestamp, formatted for longer contexts.
  *
  * @param {number} time - Milliseconds since the epoch (local time)
- * @return {string} A localized timestamp similar to what Android Messages uses
+ * @returns {string} A localized timestamp similar to what Android Messages uses
  */
 function getTime(time) {
     const date = new Date(time);
@@ -134,7 +134,7 @@ function getTime(time) {
  * Return a human-readable timestamp, formatted for shorter contexts.
  *
  * @param {number} time - Milliseconds since the epoch (local time)
- * @return {string} A localized timestamp similar to what Android Messages uses
+ * @returns {string} A localized timestamp similar to what Android Messages uses
  */
 function getShortTime(time) {
     const date = new Date(time);
@@ -175,13 +175,19 @@ function getShortTime(time) {
  * Return a human-readable timestamp, similar to `strftime()` with `%c`.
  *
  * @param {number} time - Milliseconds since the epoch (local time)
- * @return {string} A localized timestamp
+ * @returns {string} A localized timestamp
  */
 function getDetailedTime(time) {
     return _cFormat.format(time);
 }
 
 
+/**
+ * Make the avatar for an incoming message visible or invisible
+ *
+ * @param {ConversationMessage} row - The message row to modify
+ * @param {boolean} visible - Whether the avatar should be visible
+ */
 function setAvatarVisible(row, visible) {
     const incoming = row.message.type === Sms.MessageBox.INBOX;
 
@@ -546,8 +552,8 @@ const Conversation = GObject.registerClass({
      * Create a message row, ensuring a contact object has been retrieved or
      * generated for the message.
      *
-     * @param {Object} message - A dictionary of message data
-     * @return {ConversationMessage} A message row
+     * @param {object} message - A dictionary of message data
+     * @returns {ConversationMessage} A message row
      */
     _createMessageRow(message) {
         // Ensure we have a contact
@@ -655,7 +661,7 @@ const Conversation = GObject.registerClass({
     /**
      * Log the next message in the conversation.
      *
-     * @param {Object} message - A message object
+     * @param {object} message - A message object
      */
     logNext(message) {
         try {
@@ -1073,8 +1079,8 @@ export const Window = GObject.registerClass({
     /**
      * Find the thread row for @contacts
      *
-     * @param {Object[]} contacts - A contact group
-     * @return {ConversationSummary|null} The thread row or %null
+     * @param {object[]} contacts - A contact group
+     * @returns {ConversationSummary|null} The thread row or %null
      */
     _getRowForContacts(contacts) {
         const addresses = Object.keys(contacts).map(address => {
@@ -1156,8 +1162,8 @@ export const Window = GObject.registerClass({
     /**
      * Try and find an existing conversation widget for @message.
      *
-     * @param {Object} message - A message object
-     * @return {Conversation|null} A conversation widget or %null
+     * @param {object} message - A message object
+     * @returns {Conversation|null} A conversation widget or %null
      */
     getConversationForMessage(message) {
         // TODO: This shouldn't happen?
@@ -1317,4 +1323,3 @@ export const ConversationChooser = GObject.registerClass({
         this.destroy();
     }
 });
-

--- a/src/service/utils/dbus.js
+++ b/src/service/utils/dbus.js
@@ -11,12 +11,26 @@ import GObject from 'gi://GObject';
 /*
  * Some utility methods
  */
+
+/**
+ * Convert a label from kebab-case to CamelCase.
+ * Will also remove snake_case separators (without capitalizing)
+ *
+ * @param {string} string - The label to reformat
+ * @returns {string} The CamelCased label
+ */
 function toDBusCase(string) {
     return string.replace(/(?:^\w|[A-Z]|\b\w)/g, (ltr, offset) => {
         return ltr.toUpperCase();
     }).replace(/[\s_-]+/g, '');
 }
 
+/**
+ * Convert a label from CamelCase to snake_case.
+ *
+ * @param {string} string - The label to reformat
+ * @returns {string} - The snake_cased label
+ */
 function toUnderscoreCase(string) {
     return string.replace(/(?:^\w|[A-Z]|_|\b\w)/g, (ltr, offset) => {
         if (ltr === '_')
@@ -95,7 +109,7 @@ export const Interface = GObject.registerClass({
      * Invoke an instance's method for a DBus method call.
      *
      * @param {Gio.DBusInterfaceInfo} info - The DBus interface
-     * @param {DBus.Interface} iface - The DBus interface
+     * @param {Gio.DBusInterface} iface - The DBus interface
      * @param {string} name - The DBus method name
      * @param {GLib.Variant} parameters - The method parameters
      * @param {Gio.DBusMethodInvocation} invocation - The method invocation info
@@ -231,7 +245,7 @@ export const Interface = GObject.registerClass({
  *
  * @param {Gio.BusType} [busType] - a Gio.BusType constant
  * @param {Gio.Cancellable} [cancellable] - an optional Gio.Cancellable
- * @return {Promise<Gio.DBusConnection>} A new DBus connection
+ * @returns {Promise<Gio.DBusConnection>} A new DBus connection
  */
 export function newConnection(busType = Gio.BusType.SESSION, cancellable = null) {
     return new Promise((resolve, reject) => {
@@ -252,4 +266,3 @@ export function newConnection(busType = Gio.BusType.SESSION, cancellable = null)
 
     });
 }
-

--- a/src/service/utils/uri.js
+++ b/src/service/utils/uri.js
@@ -79,7 +79,7 @@ const _numberRegex = new RegExp(
  * the position within @str where the URL was found.
  *
  * @param {string} str - the string to search
- * @return {Object[]} the list of match objects, as described above
+ * @returns {object[]} the list of match objects, as described above
  */
 export function findUrls(str) {
     _urlRegexp.lastIndex = 0;
@@ -103,7 +103,7 @@ export function findUrls(str) {
  *
  * @param {string} str - The string to be modified
  * @param {string} [title] - An optional title (eg. alt text, tooltip)
- * @return {string} the modified text
+ * @returns {string} the modified text
  */
 export function linkify(str, title = null) {
     const text = GLib.markup_escape_text(str, -1);
@@ -166,4 +166,3 @@ export default class URI {
         return this.body ? `${uri}?body=${escape(this.body)}` : uri;
     }
 }
-

--- a/src/shell/clipboard.js
+++ b/src/shell/clipboard.js
@@ -183,7 +183,7 @@ export const Clipboard = GObject.registerClass({
     /**
      * Get the available mimetypes of the current clipboard content
      *
-     * @return {Promise<string[]>} A list of mime-types
+     * @returns {Promise<string[]>} A list of mime-types
      */
     GetMimetypes() {
         return new Promise((resolve, reject) => {
@@ -202,7 +202,7 @@ export const Clipboard = GObject.registerClass({
     /**
      * Get the text content of the clipboard
      *
-     * @return {Promise<string>} Text content of the clipboard
+     * @returns {Promise<string>} Text content of the clipboard
      */
     GetText() {
         return new Promise((resolve, reject) => {
@@ -241,7 +241,7 @@ export const Clipboard = GObject.registerClass({
      * Set the text content of the clipboard
      *
      * @param {string} text - text content to set
-     * @return {Promise} A promise for the operation
+     * @returns {Promise} A promise for the operation
      */
     SetText(text) {
         return new Promise((resolve, reject) => {
@@ -270,7 +270,7 @@ export const Clipboard = GObject.registerClass({
      * Get the content of the clipboard with the type @mimetype.
      *
      * @param {string} mimetype - the mimetype to request
-     * @return {Promise<Uint8Array>} The content of the clipboard
+     * @returns {Promise<Uint8Array>} The content of the clipboard
      */
     GetValue(mimetype) {
         return new Promise((resolve, reject) => {
@@ -300,7 +300,7 @@ export const Clipboard = GObject.registerClass({
      *
      * @param {Uint8Array} value - the value to set
      * @param {string} mimetype - the mimetype of the value
-     * @return {Promise} - A promise for the operation
+     * @returns {Promise} - A promise for the operation
      */
     SetValue(value, mimetype) {
         return new Promise((resolve, reject) => {
@@ -377,4 +377,3 @@ export function unwatchService() {
         _portalId = 0;
     }
 }
-

--- a/src/shell/gmenu.js
+++ b/src/shell/gmenu.js
@@ -20,7 +20,7 @@ import Tooltip from './tooltip.js';
  *
  * @param {Gio.MenuModel} model - The menu model containing the item
  * @param {number} index - The index of the item in @model
- * @return {Object} A dictionary of the item's attributes
+ * @returns {object} A dictionary of the item's attributes
  */
 function getItemInfo(model, index) {
     const info = {
@@ -644,4 +644,3 @@ export class IconBox extends PopupMenu.PopupMenuSection {
         this._onItemsChanged(this.model, 0, 0, this.model.get_n_items());
     }
 }
-

--- a/src/shell/keybindings.js
+++ b/src/shell/keybindings.js
@@ -49,7 +49,7 @@ export class Manager {
      *
      * @param {string} accelerator - An accelerator in the form '<Control>q'
      * @param {Function} callback - A callback for the accelerator
-     * @return {number} A non-zero action id on success, or 0 on failure
+     * @returns {*} A non-zero action id on success, or 0 on failure
      */
     add(accelerator, callback) {
         try {
@@ -100,4 +100,3 @@ export class Manager {
         this.removeAll();
     }
 }
-

--- a/src/shell/notification.js
+++ b/src/shell/notification.js
@@ -29,6 +29,7 @@ const REPLY_REGEX = new RegExp(/^([^|]+)\|([\s\S]+)\|([0-9a-f]{8}-[0-9a-f]{4}-[1
 /**
  * Extracted from notificationDaemon.js, as it's no longer exported
  * https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/notificationDaemon.js#L556
+ *
  * @returns {{ 'desktop-startup-id': string }} Object with ID containing current time
  */
 function getPlatformData() {
@@ -384,11 +385,17 @@ const _ensureAppSource = function (appId) {
 };
 
 
+/**
+ * Update the prototype for {@link GtkNotificationDaemon}.
+ */
 export function patchGtkNotificationDaemon() {
     GtkNotificationDaemon.prototype._ensureAppSource = _ensureAppSource;
 }
 
 
+/**
+ * Restore the prototype for {@link GtkNotificationDaemon}.
+ */
 export function unpatchGtkNotificationDaemon() {
     GtkNotificationDaemon.prototype._ensureAppSource = __ensureAppSource;
 }
@@ -399,6 +406,9 @@ export function unpatchGtkNotificationDaemon() {
  */
 const _addNotification = NotificationDaemon.GtkNotificationDaemonAppSource.prototype.addNotification;
 
+/**
+ * Update the prototype for {@link NotificationDaemon.GtkNotificationDaemonAppSource}.
+ */
 export function patchGtkNotificationSources() {
     // eslint-disable-next-line func-style
     const _withdrawGSConnectNotification = function (id, notification, reason) {
@@ -445,8 +455,10 @@ export function patchGtkNotificationSources() {
 }
 
 
+/**
+ * Restore the prototype for {@link NotificationDaemon.GtkNotificationDaemonAppSource}.
+ */
 export function unpatchGtkNotificationSources() {
     NotificationDaemon.GtkNotificationDaemonAppSource.prototype.addNotification = _addNotification;
     delete NotificationDaemon.GtkNotificationDaemonAppSource.prototype._withdrawGSConnectNotification;
 }
-

--- a/src/shell/utils.js
+++ b/src/shell/utils.js
@@ -18,7 +18,7 @@ try {
  * Get a themed icon, using fallbacks from GSConnect's GResource when necessary.
  *
  * @param {string} name - A themed icon name
- * @return {Gio.Icon} A themed icon
+ * @returns {Gio.Icon} A themed icon
  */
 export function getIcon(name) {
     if (getIcon._resource === undefined) {
@@ -71,7 +71,7 @@ export function getIcon(name) {
  * necessary.
  *
  * @param {string} relativePath - A path relative to GSConnect's resource path
- * @return {string} The file contents as a string
+ * @returns {string} The file contents as a string
  */
 function getResource(relativePath) {
     try {
@@ -96,7 +96,7 @@ function getResource(relativePath) {
  * @param {string} dirname - An absolute directory path
  * @param {string} basename - The file name
  * @param {string} contents - The file contents
- * @return {boolean} A success boolean
+ * @returns {boolean} A success boolean
  */
 function _installFile(dirname, basename, contents) {
     try {
@@ -116,7 +116,7 @@ function _installFile(dirname, basename, contents) {
  * @param {string} dirname - An absolute directory path
  * @param {string} basename - The file name
  * @param {string} relativePath - A path relative to GSConnect's resource path
- * @return {boolean} A success boolean
+ * @returns {boolean} A success boolean
  */
 function _installResource(dirname, basename, relativePath) {
     try {

--- a/src/utils/remote.js
+++ b/src/utils/remote.js
@@ -22,6 +22,13 @@ const _PROPERTIES = {
 };
 
 
+/**
+ * Initialize a Gio.DBusProxy in an awaitable manner
+ *
+ * @param {Gio.DBusProxy} proxy - The proxy object to initialize
+ * @param {Gio.Cancellable} [cancellable] - An optional cancellable object
+ * @returns {Promise} An awaitable Promise
+ */
 function _proxyInit(proxy, cancellable = null) {
     if (proxy.__initialized !== undefined)
         return Promise.resolve();
@@ -297,7 +304,7 @@ export const Service = GObject.registerClass({
      * org.freedesktop.DBus.ObjectManager.InterfacesAdded
      *
      * @param {string} object_path - Path interfaces have been added to
-     * @param {Object} interfaces - A dictionary of interface objects
+     * @param {object} interfaces - A dictionary of interface objects
      */
     async _onInterfacesAdded(object_path, interfaces) {
         try {

--- a/src/utils/setup.js
+++ b/src/utils/setup.js
@@ -23,6 +23,7 @@ export function setupGettext() {
 
 /**
  * Initialise and setup Config, GResources and GSchema.
+ *
  * @param {string} extensionPath - The absolute path to the extension directory
  */
 export default function setup(extensionPath) {

--- a/src/wl_clipboard.js
+++ b/src/wl_clipboard.js
@@ -150,11 +150,10 @@ export const Clipboard = GObject.registerClass(
         }
 
         /**
-     * Get the available mimetypes of the current clipboard content
-     *
-     * @return {Promise<string[]>} A list of mime-types
-     */
-
+         * Get the available mimetypes of the current clipboard content
+         *
+         * @returns {Promise<string[]>} A list of mime-types
+         */
         GetMimetypes() {
             return new Promise((resolve, reject) => {
                 const proc = launcher.spawnv([
@@ -179,10 +178,10 @@ export const Clipboard = GObject.registerClass(
         }
 
         /**
-     * Get the text content of the clipboard
-     *
-     * @return {Promise<string>} Text content of the clipboard
-     */
+         * Get the text content of the clipboard
+         *
+         * @returns {Promise<string>} Text content of the clipboard
+         */
         GetText() {
             return new Promise((resolve, reject) => {
                 this.GetMimetypes().then((mimetypes) => {
@@ -213,11 +212,11 @@ export const Clipboard = GObject.registerClass(
         }
 
         /**
-     * Set the text content of the clipboard
-     *
-     * @param {string} text - text content to set
-     * @return {Promise} A promise for the operation
-     */
+         * Set the text content of the clipboard
+         *
+         * @param {string} text - text content to set
+         * @returns {Promise} A promise for the operation
+         */
         SetText(text) {
             return new Promise((resolve, reject) => {
                 try {

--- a/webextension/gettext.js
+++ b/webextension/gettext.js
@@ -7,7 +7,6 @@
 import Gio from 'gi://Gio';
 import GLib from 'gi://GLib';
 
-// eslint-disable-next-line no-redeclare
 const _ = (msgid) => GLib.dgettext('org.gnome.Shell.Extensions.GSConnect', msgid);
 
 // POT Patterns
@@ -122,4 +121,3 @@ while ((info = iter.next_file(null))) {
     json = `${JSON.stringify(json, null, 4)}\n\n`;
     jsonfile.replace_contents(json, null, false, 0, null);
 }
-

--- a/webextension/js/background.js
+++ b/webextension/js/background.js
@@ -39,14 +39,22 @@ var reconnectTimer = null;
 var reconnectResetTimer = null;
 
 
-// Simple error logging function
-// eslint-disable-next-line no-redeclare
+/**
+ * Simple error logging function
+ *
+ * @param {Error} error - A caught exception
+ */
 function logError(error) {
     if (!_MUTE.includes(error.message))
         console.error(error.message);
 }
 
 
+/**
+ * Callback for activation of the extension toolbar icon
+ *
+ * @param {browser.tabs.Tab} tab - the current tab
+ */
 function toggleAction(tab = null) {
     try {
         // Disable on "about:" pages
@@ -63,9 +71,8 @@ function toggleAction(tab = null) {
 /**
  * Send a message to the native-messaging-host
  *
- * @param {Object} message - The message to forward
+ * @param {object} message - The message to forward
  */
-// eslint-disable-next-line no-redeclare
 async function postMessage(message) {
     try {
         // console.log(`WebExtension SEND: ${JSON.stringify(message)}`);
@@ -85,7 +92,7 @@ async function postMessage(message) {
 /**
  * Forward a message from the browserAction popup to the NMH
  *
- * @param {Object} message - A message from the NMH to forward
+ * @param {object} message - A message from the NMH to forward
  * @param {*} sender - A message from the NMH to forward
  */
 async function onPopupMessage(message, sender) {
@@ -101,7 +108,7 @@ async function onPopupMessage(message, sender) {
 /**
  * Forward a message from the NMH to the browserAction popup
  *
- * @param {Object} message - A message from the NMH to forward
+ * @param {object} message - A message from the NMH to forward
  */
 async function forwardPortMessage(message) {
     try {
@@ -115,7 +122,7 @@ async function forwardPortMessage(message) {
 /**
  * Context Menu Item Callback
  *
- * @param {menus.OnClickData} info - Information about the item and context
+ * @param {browser.menus.OnClickData} info - Information about the item and context
  */
 async function onContextItem(info) {
     try {
@@ -138,7 +145,7 @@ async function onContextItem(info) {
 /**
  * Populate the context menu
  *
- * @param {tabs.Tab} tab - The current tab
+ * @param {browser.tabs.Tab} tab - The current tab
  */
 async function createContextMenu(tab) {
     try {
@@ -261,7 +268,7 @@ async function createContextMenu(tab) {
 /**
  * Message Handling
  *
- * @param {Object} message - A message received from the NMH
+ * @param {object} message - A message received from the NMH
  */
 async function onPortMessage(message) {
     try {
@@ -394,4 +401,3 @@ browser.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
  */
 toggleAction();
 connect();
-

--- a/webextension/js/popup.js
+++ b/webextension/js/popup.js
@@ -19,8 +19,11 @@ const _MUTE = [
 ];
 
 
-// Simple error logging function
-// eslint-disable-next-line no-redeclare
+/**
+ * Simple error logging function
+ *
+ * @param {Error} error - A caught exception
+ */
 function logError(error) {
     if (!_MUTE.includes(error.message))
         console.error(error.message);
@@ -56,7 +59,7 @@ async function sendUrl(device, action, url) {
  * Create and return a device element for the popup menu
  *
  * @param {object} device - A JSON object describing a connected device
- * @return {HTMLElement} - A <div> element with icon, name and actions
+ * @returns {HTMLElement} - A <div> element with icon, name and actions
  */
 function getDeviceElement(device) {
     const deviceElement = document.createElement('div');
@@ -136,8 +139,8 @@ function setPopup() {
 /**
  * Callback for receiving a message forwarded by background.js
  *
- * @param {Object} message - A JSON message object
- * @param {runtime.MessageSender} sender - The sender of the message.
+ * @param {object} message - A JSON message object
+ * @param {browser.runtime.MessageSender} sender - The sender of the message.
  */
 function onPortMessage(message, sender) {
     try {
@@ -185,4 +188,3 @@ async function onPopup() {
  */
 browser.runtime.onMessage.addListener(onPortMessage);
 document.addEventListener('DOMContentLoaded', onPopup);
-


### PR DESCRIPTION
This PR mostly modifies docstrings, to eliminate warnings being reported by ESLint's jsdoc plugin. (The fifth commit does make one relatively-inconsequential code change.)

A few new imports were added to some modules, for the sole purpose of getting types used in docstrings defined. (Mostly that involved importing `Core` to get at `Core.Packet`.) That potentially adds a bit of overhead, but it should be minimal since the imported modules will already be loaded. (**Edit:** Well, it would, if I hadn't screwed up a bunch of the relative paths. Fixed now, hopefully.)

One condition is also turned into an error: Failing to leave exactly blank line between the doctring's function description, and the set of tags that follow.

So, both of these will now be errors:

```js
/**
 * Update the player with an object of properties and values.
 *
 *
 * @param {object} obj - A dictionary of properties
 */

/**
 * Update the player with an object of properties and values.
 * @param {object} obj - A dictionary of properties
 */
```