### PR TITLE
Protocol v7 main

### DIFF
--- a/installed-tests/fixtures/backend.js
+++ b/installed-tests/fixtures/backend.js
@@ -292,7 +292,7 @@ export const ChannelService = GObject.registerClass({
                 deviceId: this.id,
                 deviceName: this.name,
                 deviceType: 'desktop',
-                protocolVersion: 8,
+                protocolVersion: 7,
                 incomingCapabilities: [],
                 outgoingCapabilities: [],
                 tcpPort: this.port,

--- a/installed-tests/fixtures/utils.js
+++ b/installed-tests/fixtures/utils.js
@@ -147,7 +147,7 @@ export function generateIdentity(params = {}) {
             'deviceId': Device.generateId(),
             'deviceName': 'Test Device',
             'deviceType': getDeviceType(),
-            'protocolVersion': 8,
+            'protocolVersion': 7,
             'incomingCapabilities': [],
             'outgoingCapabilities': [],
         },

--- a/src/service/backends/lan.js
+++ b/src/service/backends/lan.js
@@ -753,13 +753,6 @@ export const Channel = GObject.registerClass({
                 throw new Error(`invalid deviceName "${this.identity.body.deviceName}"`);
 
             this._connection = await this._encryptClient(connection);
-
-            // Starting with protocol version 8, the devices are expected to
-            // exchange identity packets again after TLS negotiation
-            if (this.identity.body.protocolVersion >= 8) {
-                await this.sendPacket(this.backend.identity);
-                this.identity = await this.readPacket();
-            }
         } catch (e) {
             this.close();
             throw e;
@@ -784,13 +777,6 @@ export const Channel = GObject.registerClass({
                 this.cancellable);
 
             this._connection = await this._encryptServer(connection);
-
-            // Starting with protocol version 8, the devices are expected to
-            // exchange identity packets again after TLS negotiation
-            if (this.identity.body.protocolVersion >= 8) {
-                await this.sendPacket(this.backend.identity);
-                this.identity = await this.readPacket();
-            }
         } catch (e) {
             this.close();
             throw e;

--- a/src/service/core.js
+++ b/src/service/core.js
@@ -407,7 +407,7 @@ export const ChannelService = GObject.registerClass({
                 deviceId: this.id,
                 deviceName: this.name,
                 deviceType: _getDeviceType(),
-                protocolVersion: 8,
+                protocolVersion: 7,
                 incomingCapabilities: [],
                 outgoingCapabilities: [],
             },


### PR DESCRIPTION
I cherry picked commits individually since v58 to this branch, skipping the [commit flipping protocol version to 8](https://github.com/GSConnect/gnome-shell-extension-gsconnect/commit/c792f86fcf7857a5dba02c1f806b64c49a14531e). It can be cherry picked cleanly on top, and breaks my Android 11 device with latest KDE Connect Android.

That Android 11 KDE Connect doesn't work with latest KDE Connect Android on an Android 14 device either, so I'm pretty sure the error is on that end, but IMO we really shouldn't rush into forcing protocol v8 only before even KDE Connect proper does it, considering there's such a show stopper issue.