### PR TITLE
Remove the default export from utils/setup

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -23,7 +23,7 @@ import * as Keybindings from './shell/keybindings.js';
 import * as Notification from './shell/notification.js';
 import * as Input from './shell/input.js';
 import * as Remote from './utils/remote.js';
-import setup, * as Setup from './utils/setup.js';
+import * as Setup from './utils/setup.js';
 
 const QuickSettingsMenu = Main.panel.statusArea.quickSettings;
 
@@ -357,7 +357,7 @@ export default class GSConnectExtension extends Extension {
 
     constructor(metadata) {
         super(metadata);
-        setup(this.path);
+        Setup.setup(this.path);
 
         // If installed as a user extension, this checks the permissions
         // on certain critical files in the extension directory

--- a/src/preferences/init.js
+++ b/src/preferences/init.js
@@ -4,7 +4,7 @@
 
 import GLib from 'gi://GLib';
 
-import setup, {setupGettext} from '../utils/setup.js';
+import {setup, setupGettext} from '../utils/setup.js';
 
 
 // Bootstrap

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -7,13 +7,13 @@ import GLib from 'gi://GLib';
 import Adw from 'gi://Adw';
 
 // Bootstrap
-import setup, * as Setup from './utils/setup.js';
+import * as Setup from './utils/setup.js';
 import {ExtensionPreferences} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
 export default class GSConnectExtensionPreferences extends ExtensionPreferences {
     constructor(metadata) {
         super(metadata);
-        setup(this.path);
+        Setup.setup(this.path);
         Setup.ensurePermissions();
         Setup.installService();
     }

--- a/src/service/init.js
+++ b/src/service/init.js
@@ -9,7 +9,7 @@ import GIRepository from 'gi://GIRepository';
 import GLib from 'gi://GLib';
 
 import Config from '../config.js';
-import setup, {setupGettext} from '../utils/setup.js';
+import {setup, setupGettext} from '../utils/setup.js';
 
 
 // Promise Wrappers

--- a/src/utils/setup.js
+++ b/src/utils/setup.js
@@ -242,7 +242,7 @@ export function installService() {
  *
  * @param {string} extensionPath - The absolute path to the extension directory
  */
-export default function setup(extensionPath) {
+export function setup(extensionPath) {
     // Ensure config.js is setup properly
     Config.PACKAGE_DATADIR = extensionPath;
     const userDir = GLib.build_filenamev([GLib.get_user_data_dir(), 'gnome-shell']);


### PR DESCRIPTION
We no longer ever need _just_ that function, so having it be the default export only makes the imports more awkward. Demote it to a regular named export, and import what we need from the module when we need it.

This grew out of #1933, where @retrixe moved additional functions into the module. That highlighted the (already-existing) awkwardness in how we consume the module's exports.
