### PR TITLE
fix(daemon): fix device migration code

### DIFF
--- a/installed-tests/suites/backends/testLanBackend.js
+++ b/installed-tests/suites/backends/testLanBackend.js
@@ -23,7 +23,6 @@ describe('A LAN channel service', function () {
         );
 
         local = new Lan.ChannelService({
-            id: localCert.common_name,
             certificate: localCert,
             port: 1717,
         });
@@ -34,7 +33,6 @@ describe('A LAN channel service', function () {
         );
 
         remote = new Lan.ChannelService({
-            id: remoteCert.common_name,
             certificate: remoteCert,
             port: 1718,
         });

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -23,6 +23,7 @@ src/preferences/keybindings.js
 src/preferences/service.js
 src/service/daemon.js
 src/service/device.js
+src/service/init.js
 src/service/manager.js
 src/service/backends/lan.js
 src/service/plugins/battery.js

--- a/src/service/backends/lan.js
+++ b/src/service/backends/lan.js
@@ -361,15 +361,15 @@ export const ChannelService = GObject.registerClass({
                 return;
 
             // Reject invalid device IDs
-            if (!Device.validateId(this.identity.body.deviceId))
-                throw new Error(`invalid deviceId "${this.identity.body.deviceId}"`);
+            if (!Device.validateId(packet.body.deviceId))
+                throw new Error(`invalid deviceId "${packet.body.deviceId}"`);
 
-            if (!this.identity.body.deviceName)
+            if (!packet.body.deviceName)
                 throw new Error('missing deviceName');
 
             // Reject invalid device names
-            if (!Device.validateName(this.identity.body.deviceName))
-                throw new Error(`invalid deviceName "${this.identity.body.deviceName}"`);
+            if (!Device.validateName(packet.body.deviceName))
+                throw new Error(`invalid deviceName "${packet.body.deviceName}"`);
 
             debug(packet);
 

--- a/src/service/backends/lan.js
+++ b/src/service/backends/lan.js
@@ -173,13 +173,6 @@ export const ChannelService = GObject.registerClass({
     }
 
     _initCertificate() {
-        if (GLib.find_program_in_path(Config.OPENSSL_PATH) === null) {
-            const error = new Error();
-            error.name = _('OpenSSL not found');
-            error.url = `${Config.PACKAGE_URL}/wiki/Error#openssl-not-found`;
-            throw error;
-        }
-
         const certPath = GLib.build_filenamev([
             Config.CONFIGDIR,
             'certificate.pem',

--- a/src/service/backends/lan.js
+++ b/src/service/backends/lan.js
@@ -149,6 +149,10 @@ export const ChannelService = GObject.registerClass({
         return this._channels;
     }
 
+    get id() {
+        return this.certificate.common_name;
+    }
+
     get port() {
         if (this._port === undefined)
             this._port = PROTOCOL_PORT_DEFAULT;
@@ -184,12 +188,7 @@ export const ChannelService = GObject.registerClass({
 
         // Ensure a certificate exists with our id as the common name
         this._certificate = Gio.TlsCertificate.new_for_paths(certPath, keyPath,
-            this.id);
-
-        // If the service ID doesn't match the common name, this is probably a
-        // certificate from an older version and we should amend ours to match
-        if (this.id !== this._certificate.common_name)
-            this._id = this._certificate.common_name;
+            null);
     }
 
     _initTcpListener() {

--- a/src/service/device.js
+++ b/src/service/device.js
@@ -132,11 +132,11 @@ const Device = GObject.registerClass({
     }
 
     static generateId() {
-        return GLib.uuid_string_random().replaceAll('-', '_');
+        return GLib.uuid_string_random().replaceAll('-', '');
     }
 
     static validateId(id) {
-        return /^[a-zA-Z0-9_]{32,38}$/.test(id);
+        return /^[a-zA-Z0-9_-]{32,38}$/.test(id);
     }
 
     static validateName(name) {

--- a/src/service/init.js
+++ b/src/service/init.js
@@ -355,7 +355,7 @@ Gio.TlsCertificate.new_for_paths = function (certPath, keyPath, commonName = nul
     if (!certExists || !keyExists) {
         // If we weren't passed a common name, generate a random one
         if (!commonName)
-            commonName = GLib.uuid_string_random().replaceAll('-', '_');
+            commonName = GLib.uuid_string_random().replaceAll('-', '');
 
         const proc = new Gio.Subprocess({
             argv: [

--- a/src/service/init.js
+++ b/src/service/init.js
@@ -340,6 +340,13 @@ GLib.Variant.prototype.full_unpack = _full_unpack;
  * @returns {Gio.TlsCertificate} A TLS certificate
  */
 Gio.TlsCertificate.new_for_paths = function (certPath, keyPath, commonName = null) {
+    if (GLib.find_program_in_path(Config.OPENSSL_PATH) === null) {
+        const error = new Error();
+        error.name = _('OpenSSL not found');
+        error.url = `${Config.PACKAGE_URL}/wiki/Error#openssl-not-found`;
+        throw error;
+    }
+
     // Check if the certificate/key pair already exists
     const certExists = GLib.file_test(certPath, GLib.FileTest.EXISTS);
     const keyExists = GLib.file_test(keyPath, GLib.FileTest.EXISTS);

--- a/src/service/manager.js
+++ b/src/service/manager.js
@@ -43,6 +43,13 @@ const Manager = GObject.registerClass({
             GObject.ParamFlags.READWRITE,
             false
         ),
+        'certificate': GObject.ParamSpec.object(
+            'certificate',
+            'Certificate',
+            'The local TLS certificate',
+            GObject.ParamFlags.READABLE,
+            Gio.TlsCertificate
+        ),
         'discoverable': GObject.ParamSpec.boolean(
             'discoverable',
             'Discoverable',
@@ -54,7 +61,7 @@ const Manager = GObject.registerClass({
             'id',
             'Id',
             'The hostname or other network unique id',
-            GObject.ParamFlags.READWRITE,
+            GObject.ParamFlags.READABLE,
             null
         ),
         'name': GObject.ParamSpec.string(
@@ -91,6 +98,17 @@ const Manager = GObject.registerClass({
             this._backends = new Map();
 
         return this._backends;
+    }
+
+    get certificate() {
+        if (this._certificate === undefined) {
+            this._certificate = Gio.TlsCertificate.new_for_paths(
+                GLib.build_filenamev([Config.CONFIGDIR, 'certificate.pem']),
+                GLib.build_filenamev([Config.CONFIGDIR, 'private.pem']),
+                null);
+        }
+
+        return this._certificate;
     }
 
     get debug() {
@@ -157,18 +175,7 @@ const Manager = GObject.registerClass({
     }
 
     get id() {
-        if (this._id === undefined)
-            this._id = this.settings.get_string('id');
-
-        return this._id;
-    }
-
-    set id(value) {
-        if (this.id === value)
-            return;
-
-        this._id = value;
-        this.notify('id');
+        return this.certificate.common_name;
     }
 
     get name() {
@@ -218,17 +225,12 @@ const Manager = GObject.registerClass({
      * GSettings
      */
     _initSettings() {
-        // Initialize the ID and name of the service
-        if (this.settings.get_string('id').length === 0)
-            this.settings.set_string('id', Device.generateId());
-
         if (this.settings.get_string('name').length === 0)
             this.settings.set_string('name', GLib.get_host_name());
 
         // Bound Properties
         this.settings.bind('debug', this, 'debug', 0);
         this.settings.bind('discoverable', this, 'discoverable', 0);
-        this.settings.bind('id', this, 'id', 0);
         this.settings.bind('name', this, 'name', 0);
     }
 

--- a/src/service/manager.js
+++ b/src/service/manager.js
@@ -425,7 +425,7 @@ const Manager = GObject.registerClass({
      */
     _removeDevice(id) {
         // Delete all GSettings
-        const settings_path = `/org/gnome/shell/extensions/gsconnect/${id}/`;
+        const settings_path = `/org/gnome/shell/extensions/gsconnect/device/${id}/`;
         GLib.spawn_command_line_async(`dconf reset -f ${settings_path}`);
 
         // Delete the cache


### PR DESCRIPTION
Fix the migration code by always checking the certificate common
name and avoiding any dependency on the manager object.

Also fix the device ID and name validation for incoming
broadcasts and the settings path, when clearing settings.

closes #1960