### PR TITLE
fix(daemon): fix device migration code (GNOME 45)

### DIFF
--- a/installed-tests/suites/backends/testLanBackend.js
+++ b/installed-tests/suites/backends/testLanBackend.js
@@ -24,7 +24,6 @@ describe('A LAN channel service', function () {
         );
 
         local = new Lan.ChannelService({
-            id: localCert.common_name,
             certificate: localCert,
             port: 1717,
         });
@@ -35,7 +34,6 @@ describe('A LAN channel service', function () {
         );
 
         remote = new Lan.ChannelService({
-            id: remoteCert.common_name,
             certificate: remoteCert,
             port: 1718,
         });

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -23,6 +23,7 @@ src/preferences/keybindings.js
 src/preferences/service.js
 src/service/daemon.js
 src/service/device.js
+src/service/init.js
 src/service/manager.js
 src/service/backends/lan.js
 src/service/plugins/battery.js

--- a/src/service/backends/lan.js
+++ b/src/service/backends/lan.js
@@ -141,6 +141,10 @@ var ChannelService = GObject.registerClass({
         return this._channels;
     }
 
+    get id() {
+        return this.certificate.common_name;
+    }
+
     get port() {
         if (this._port === undefined)
             this._port = PROTOCOL_PORT_DEFAULT;
@@ -176,12 +180,7 @@ var ChannelService = GObject.registerClass({
 
         // Ensure a certificate exists with our id as the common name
         this._certificate = Gio.TlsCertificate.new_for_paths(certPath, keyPath,
-            this.id);
-
-        // If the service ID doesn't match the common name, this is probably a
-        // certificate from an older version and we should amend ours to match
-        if (this.id !== this._certificate.common_name)
-            this._id = this._certificate.common_name;
+            null);
     }
 
     _initTcpListener() {

--- a/src/service/backends/lan.js
+++ b/src/service/backends/lan.js
@@ -165,13 +165,6 @@ var ChannelService = GObject.registerClass({
     }
 
     _initCertificate() {
-        if (GLib.find_program_in_path(Config.OPENSSL_PATH) === null) {
-            const error = new Error();
-            error.name = _('OpenSSL not found');
-            error.url = `${Config.PACKAGE_URL}/wiki/Error#openssl-not-found`;
-            throw error;
-        }
-
         const certPath = GLib.build_filenamev([
             Config.CONFIGDIR,
             'certificate.pem',

--- a/src/service/backends/lan.js
+++ b/src/service/backends/lan.js
@@ -353,15 +353,15 @@ var ChannelService = GObject.registerClass({
                 return;
 
             // Reject invalid device IDs
-            if (!Device.Device.validateId(this.identity.body.deviceId))
-                throw new Error(`invalid deviceId "${this.identity.body.deviceId}"`);
+            if (!Device.Device.validateId(packet.body.deviceId))
+                throw new Error(`invalid deviceId "${packet.body.deviceId}"`);
 
-            if (!this.identity.body.deviceName)
+            if (!packet.body.deviceName)
                 throw new Error('missing deviceName');
 
             // Reject invalid device names
-            if (!Device.Device.validateName(this.identity.body.deviceName))
-                throw new Error(`invalid deviceName "${this.identity.body.deviceName}"`);
+            if (!Device.Device.validateName(packet.body.deviceName))
+                throw new Error(`invalid deviceName "${packet.body.deviceName}"`);
 
             debug(packet);
 

--- a/src/service/daemon.js
+++ b/src/service/daemon.js
@@ -66,7 +66,14 @@ const Service = GObject.registerClass({
     }
 
     _migrateConfiguration() {
-        if (Device.Device.validateId(this.settings.get_string('id')))
+        const [certPath, keyPath] = [
+            GLib.build_filenamev([Config.CONFIGDIR, 'certificate.pem']),
+            GLib.build_filenamev([Config.CONFIGDIR, 'private.pem']),
+        ];
+        const certificate = Gio.TlsCertificate.new_for_paths(certPath, keyPath,
+            null);
+
+        if (Device.Device.validateId(certificate.common_name))
             return;
 
         if (!Device.Device.validateName(this.settings.get_string('name')))
@@ -75,30 +82,32 @@ const Service = GObject.registerClass({
         // Remove the old certificate, serving as the single source of truth
         // for the device ID
         try {
-            Gio.File.new_build_filenamev([Config.CONFIGDIR, 'certificate.pem'])
-                .delete(null);
-            Gio.File.new_build_filenamev([Config.CONFIGDIR, 'private.pem'])
-                .delete(null);
+            Gio.File.new_for_path(certPath).delete(null);
+            Gio.File.new_for_path(keyPath).delete(null);
         } catch {
             // Silence errors
         }
 
         // For each device, remove it entirely if it violates the device ID
         // constraints, otherwise mark it unpaired to preserve the settings.
-        for (const deviceId of this.settings.get_strv('devices')) {
-            if (!Device.Device.validateId(deviceId)) {
-                this._removeDevice(deviceId);
-            } else {
-                const settings = new Gio.Settings({
-                    settings_schema: Config.GSCHEMA.lookup(
-                        'org.gnome.Shell.Extensions.GSConnect.Device',
-                        true
-                    ),
-                    path: `/org/gnome/shell/extensions/gsconnect/device/${deviceId}/`,
-                });
-                settings.set_boolean('paired', false);
+        const deviceList = this.settings.get_strv('devices').filter(id => {
+            const settingsPath = `/org/gnome/shell/extensions/gsconnect/device/${id}/`;
+            if (!Device.Device.validateId(id)) {
+                GLib.spawn_command_line_async(`dconf reset -f ${settingsPath}`);
+                Gio.File.rm_rf(GLib.build_filenamev([Config.CACHEDIR, id]));
+                debug(`Invalid device ID ${id} removed.`);
+                return false;
             }
-        }
+
+            const settings = new Gio.Settings({
+                settings_schema: Config.GSCHEMA.lookup(
+                    'org.gnome.Shell.Extensions.GSConnect.Device', true),
+                path: settingsPath,
+            });
+            settings.set_boolean('paired', false);
+            return true;
+        });
+        this.settings.set_strv('devices', deviceList);
 
         // Notify the user
         const notification = Gio.Notification.new(_('Settings Migrated'));
@@ -307,6 +316,9 @@ const Service = GObject.registerClass({
         // GActions & GSettings
         this._initActions();
 
+        // TODO: remove after a reasonable period of time
+        this._migrateConfiguration();
+
         this.manager.start();
     }
 
@@ -314,8 +326,6 @@ const Service = GObject.registerClass({
         if (!super.vfunc_dbus_register(connection, object_path))
             return false;
 
-        // TODO: remove after a reasonable period of time
-        this._migrateConfiguration();
         this.manager = new Manager.Manager({
             connection: connection,
             object_path: object_path,

--- a/src/service/device.js
+++ b/src/service/device.js
@@ -134,11 +134,11 @@ var Device = GObject.registerClass({
     }
 
     static generateId() {
-        return GLib.uuid_string_random().replaceAll('-', '_');
+        return GLib.uuid_string_random().replaceAll('-', '');
     }
 
     static validateId(id) {
-        return /^[a-zA-Z0-9_]{32,38}$/.test(id);
+        return /^[a-zA-Z0-9_-]{32,38}$/.test(id);
     }
 
     static validateName(name) {

--- a/src/service/manager.js
+++ b/src/service/manager.js
@@ -388,7 +388,7 @@ var Manager = GObject.registerClass({
      */
     _removeDevice(id) {
         // Delete all GSettings
-        const settings_path = `/org/gnome/shell/extensions/gsconnect/${id}/`;
+        const settings_path = `/org/gnome/shell/extensions/gsconnect/device/${id}/`;
         GLib.spawn_command_line_async(`dconf reset -f ${settings_path}`);
 
         // Delete the cache

--- a/src/service/utils/setup.js
+++ b/src/service/utils/setup.js
@@ -363,7 +363,7 @@ Gio.TlsCertificate.new_for_paths = function (certPath, keyPath, commonName = nul
     if (!certExists || !keyExists) {
         // If we weren't passed a common name, generate a random one
         if (!commonName)
-            commonName = GLib.uuid_string_random().replaceAll('-', '_');
+            commonName = GLib.uuid_string_random().replaceAll('-', '');
 
         const proc = new Gio.Subprocess({
             argv: [

--- a/src/service/utils/setup.js
+++ b/src/service/utils/setup.js
@@ -348,6 +348,13 @@ GLib.Variant.prototype.full_unpack = _full_unpack;
  * @return {Gio.TlsCertificate} A TLS certificate
  */
 Gio.TlsCertificate.new_for_paths = function (certPath, keyPath, commonName = null) {
+    if (GLib.find_program_in_path(Config.OPENSSL_PATH) === null) {
+        const error = new Error();
+        error.name = _('OpenSSL not found');
+        error.url = `${Config.PACKAGE_URL}/wiki/Error#openssl-not-found`;
+        throw error;
+    }
+
     // Check if the certificate/key pair already exists
     const certExists = GLib.file_test(certPath, GLib.FileTest.EXISTS);
     const keyExists = GLib.file_test(keyPath, GLib.FileTest.EXISTS);


### PR DESCRIPTION
Fix the migration code by always checking the certificate common
name and avoiding any dependency on the manager object.

Also fix the device ID and name validation for incoming
broadcasts and the settings path, when clearing settings.