### PR TITLE
fix(daemon): fix device migration code (GNOME 43)

### DIFF
--- a/installed-tests/suites/backends/testLanBackend.js
+++ b/installed-tests/suites/backends/testLanBackend.js
@@ -20,7 +20,6 @@ describe('A LAN channel service', function () {
         );
 
         local = new Lan.ChannelService({
-            id: localCert.common_name,
             certificate: localCert,
             port: 1717,
         });
@@ -31,7 +30,6 @@ describe('A LAN channel service', function () {
         );
 
         remote = new Lan.ChannelService({
-            id: remoteCert.common_name,
             certificate: remoteCert,
             port: 1718,
         });

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -23,6 +23,7 @@ src/preferences/keybindings.js
 src/preferences/service.js
 src/service/daemon.js
 src/service/device.js
+src/service/init.js
 src/service/manager.js
 src/service/backends/lan.js
 src/service/plugins/battery.js

--- a/src/service/__init__.js
+++ b/src/service/__init__.js
@@ -338,7 +338,7 @@ Gio.TlsCertificate.new_for_paths = function (certPath, keyPath, commonName = nul
     if (!certExists || !keyExists) {
         // If we weren't passed a common name, generate a random one
         if (!commonName)
-            commonName = GLib.uuid_string_random().replaceAll('-', '_');
+            commonName = GLib.uuid_string_random().replaceAll('-', '');
 
         const proc = new Gio.Subprocess({
             argv: [

--- a/src/service/__init__.js
+++ b/src/service/__init__.js
@@ -323,6 +323,13 @@ GLib.Variant.prototype.full_unpack = _full_unpack;
  * @returns {Gio.TlsCertificate} A TLS certificate
  */
 Gio.TlsCertificate.new_for_paths = function (certPath, keyPath, commonName = null) {
+    if (GLib.find_program_in_path(Config.OPENSSL_PATH) === null) {
+        const error = new Error();
+        error.name = _('OpenSSL not found');
+        error.url = `${Config.PACKAGE_URL}/wiki/Error#openssl-not-found`;
+        throw error;
+    }
+
     // Check if the certificate/key pair already exists
     const certExists = GLib.file_test(certPath, GLib.FileTest.EXISTS);
     const keyExists = GLib.file_test(keyPath, GLib.FileTest.EXISTS);

--- a/src/service/backends/lan.js
+++ b/src/service/backends/lan.js
@@ -334,15 +334,15 @@ var ChannelService = GObject.registerClass({
                 return;
 
             // Reject invalid device IDs
-            if (!Device.Device.validateId(this.identity.body.deviceId))
-                throw new Error(`invalid deviceId "${this.identity.body.deviceId}"`);
+            if (!Device.Device.validateId(packet.body.deviceId))
+                throw new Error(`invalid deviceId "${packet.body.deviceId}"`);
 
-            if (!this.identity.body.deviceName)
+            if (!packet.body.deviceName)
                 throw new Error('missing deviceName');
 
             // Reject invalid device names
-            if (!Device.Device.validateName(this.identity.body.deviceName))
-                throw new Error(`invalid deviceName "${this.identity.body.deviceName}"`);
+            if (!Device.Device.validateName(packet.body.deviceName))
+                throw new Error(`invalid deviceName "${packet.body.deviceName}"`);
 
             debug(packet);
 

--- a/src/service/backends/lan.js
+++ b/src/service/backends/lan.js
@@ -158,13 +158,6 @@ var ChannelService = GObject.registerClass({
     }
 
     _initCertificate() {
-        if (GLib.find_program_in_path(Config.OPENSSL_PATH) === null) {
-            const error = new Error();
-            error.name = _('OpenSSL not found');
-            error.url = `${Config.PACKAGE_URL}/wiki/Error#openssl-not-found`;
-            throw error;
-        }
-
         const certPath = GLib.build_filenamev([
             Config.CONFIGDIR,
             'certificate.pem',

--- a/src/service/backends/lan.js
+++ b/src/service/backends/lan.js
@@ -134,6 +134,10 @@ var ChannelService = GObject.registerClass({
         return this._channels;
     }
 
+    get id() {
+        return this.certificate.common_name;
+    }
+
     get port() {
         if (this._port === undefined)
             this._port = DEFAULT_PORT;
@@ -169,12 +173,7 @@ var ChannelService = GObject.registerClass({
 
         // Ensure a certificate exists with our id as the common name
         this._certificate = Gio.TlsCertificate.new_for_paths(certPath, keyPath,
-            this.id);
-
-        // If the service ID doesn't match the common name, this is probably a
-        // certificate from an older version and we should amend ours to match
-        if (this.id !== this._certificate.common_name)
-            this._id = this._certificate.common_name;
+            null);
     }
 
     _initTcpListener() {

--- a/src/service/daemon.js
+++ b/src/service/daemon.js
@@ -64,7 +64,14 @@ const Service = GObject.registerClass({
     }
 
     _migrateConfiguration() {
-        if (Device.Device.validateId(this.settings.get_string('id')))
+        const [certPath, keyPath] = [
+            GLib.build_filenamev([Config.CONFIGDIR, 'certificate.pem']),
+            GLib.build_filenamev([Config.CONFIGDIR, 'private.pem']),
+        ];
+        const certificate = Gio.TlsCertificate.new_for_paths(certPath, keyPath,
+            null);
+
+        if (Device.Device.validateId(certificate.common_name))
             return;
 
         if (!Device.Device.validateName(this.settings.get_string('name')))
@@ -73,30 +80,32 @@ const Service = GObject.registerClass({
         // Remove the old certificate, serving as the single source of truth
         // for the device ID
         try {
-            Gio.File.new_build_filenamev([Config.CONFIGDIR, 'certificate.pem'])
-                .delete(null);
-            Gio.File.new_build_filenamev([Config.CONFIGDIR, 'private.pem'])
-                .delete(null);
+            Gio.File.new_for_path(certPath).delete(null);
+            Gio.File.new_for_path(keyPath).delete(null);
         } catch (e) {
             // Silence errors
         }
 
         // For each device, remove it entirely if it violates the device ID
         // constraints, otherwise mark it unpaired to preserve the settings.
-        for (const deviceId of this.settings.get_strv('devices')) {
-            if (!Device.Device.validateId(deviceId)) {
-                this._removeDevice(deviceId);
-            } else {
-                const settings = new Gio.Settings({
-                    settings_schema: Config.GSCHEMA.lookup(
-                        'org.gnome.Shell.Extensions.GSConnect.Device',
-                        true
-                    ),
-                    path: `/org/gnome/shell/extensions/gsconnect/device/${deviceId}/`,
-                });
-                settings.set_boolean('paired', false);
+        const deviceList = this.settings.get_strv('devices').filter(id => {
+            const settingsPath = `/org/gnome/shell/extensions/gsconnect/device/${id}/`;
+            if (!Device.Device.validateId(id)) {
+                GLib.spawn_command_line_async(`dconf reset -f ${settingsPath}`);
+                Gio.File.rm_rf(GLib.build_filenamev([Config.CACHEDIR, id]));
+                debug(`Invalid device ID ${id} removed.`);
+                return false;
             }
-        }
+
+            const settings = new Gio.Settings({
+                settings_schema: Config.GSCHEMA.lookup(
+                    'org.gnome.Shell.Extensions.GSConnect.Device', true),
+                path: settingsPath,
+            });
+            settings.set_boolean('paired', false);
+            return true;
+        });
+        this.settings.set_strv('devices', deviceList);
 
         // Notify the user
         const notification = Gio.Notification.new(_('Settings Migrated'));
@@ -305,6 +314,9 @@ const Service = GObject.registerClass({
         // GActions & GSettings
         this._initActions();
 
+        // TODO: remove after a reasonable period of time
+        this._migrateConfiguration();
+
         this.manager.start();
     }
 
@@ -312,8 +324,6 @@ const Service = GObject.registerClass({
         if (!super.vfunc_dbus_register(connection, object_path))
             return false;
 
-        // TODO: remove after a reasonable period of time
-        this._migrateConfiguration();
         this.manager = new Manager.Manager({
             connection: connection,
             object_path: object_path,

--- a/src/service/device.js
+++ b/src/service/device.js
@@ -130,11 +130,11 @@ var Device = GObject.registerClass({
     }
 
     static generateId() {
-        return GLib.uuid_string_random().replaceAll('-', '_');
+        return GLib.uuid_string_random().replaceAll('-', '');
     }
 
     static validateId(id) {
-        return /^[a-zA-Z0-9_]{32,38}$/.test(id);
+        return /^[a-zA-Z0-9_-]{32,38}$/.test(id);
     }
 
     static validateName(name) {

--- a/src/service/manager.js
+++ b/src/service/manager.js
@@ -26,6 +26,13 @@ var Manager = GObject.registerClass({
             GObject.ParamFlags.READABLE,
             false
         ),
+        'certificate': GObject.ParamSpec.object(
+            'certificate',
+            'Certificate',
+            'The local TLS certificate',
+            GObject.ParamFlags.READABLE,
+            Gio.TlsCertificate
+        ),
         'discoverable': GObject.ParamSpec.boolean(
             'discoverable',
             'Discoverable',
@@ -37,7 +44,7 @@ var Manager = GObject.registerClass({
             'id',
             'Id',
             'The hostname or other network unique id',
-            GObject.ParamFlags.READWRITE,
+            GObject.ParamFlags.READABLE,
             null
         ),
         'name': GObject.ParamSpec.string(
@@ -74,6 +81,17 @@ var Manager = GObject.registerClass({
             this._backends = new Map();
 
         return this._backends;
+    }
+
+    get certificate() {
+        if (this._certificate === undefined) {
+            this._certificate = Gio.TlsCertificate.new_for_paths(
+                GLib.build_filenamev([Config.CONFIGDIR, 'certificate.pem']),
+                GLib.build_filenamev([Config.CONFIGDIR, 'private.pem']),
+                null);
+        }
+
+        return this._certificate;
     }
 
     get devices() {
@@ -125,18 +143,7 @@ var Manager = GObject.registerClass({
     }
 
     get id() {
-        if (this._id === undefined)
-            this._id = this.settings.get_string('id');
-
-        return this._id;
-    }
-
-    set id(value) {
-        if (this.id === value)
-            return;
-
-        this._id = value;
-        this.notify('id');
+        return this.certificate.common_name;
     }
 
     get name() {
@@ -186,16 +193,11 @@ var Manager = GObject.registerClass({
      * GSettings
      */
     _initSettings() {
-        // Initialize the ID and name of the service
-        if (this.settings.get_string('id').length === 0)
-            this.settings.set_string('id', Device.Device.generateId());
-
         if (this.settings.get_string('name').length === 0)
             this.settings.set_string('name', GLib.get_host_name());
 
         // Bound Properties
         this.settings.bind('discoverable', this, 'discoverable', 0);
-        this.settings.bind('id', this, 'id', 0);
         this.settings.bind('name', this, 'name', 0);
     }
 

--- a/src/service/manager.js
+++ b/src/service/manager.js
@@ -384,7 +384,7 @@ var Manager = GObject.registerClass({
      */
     _removeDevice(id) {
         // Delete all GSettings
-        const settings_path = `/org/gnome/shell/extensions/gsconnect/${id}/`;
+        const settings_path = `/org/gnome/shell/extensions/gsconnect/device/${id}/`;
         GLib.spawn_command_line_async(`dconf reset -f ${settings_path}`);
 
         // Delete the cache


### PR DESCRIPTION
Fix the migration code by always checking the certificate common
name and avoiding any dependency on the manager object.

Also fix the device ID and name validation for incoming
broadcasts and the settings path, when clearing settings.