### PR TITLE
Fix send file functionality adding a " (1)" after the extension

### DIFF
--- a/src/service/plugins/share.js
+++ b/src/service/plugins/share.js
@@ -10,6 +10,7 @@ import Gtk from 'gi://Gtk';
 
 import Plugin from '../plugin.js';
 import * as URI from '../utils/uri.js';
+import * as Filename from '../utils/filename.js';
 
 
 export const Metadata = {
@@ -113,10 +114,9 @@ const SharePlugin = GObject.registerClass({
         const dirpath = this._ensureReceiveDirectory();
         const basepath = GLib.build_filenamev([dirpath, filename]);
         let filepath = basepath;
-        let copyNum = 0;
 
         while (GLib.file_test(filepath, GLib.FileTest.EXISTS))
-            filepath = `${basepath} (${++copyNum})`;
+            filepath = Filename.makeUnique(filepath);
 
         return Gio.File.new_for_path(filepath);
     }

--- a/src/service/utils/filename.js
+++ b/src/service/utils/filename.js
@@ -1,0 +1,45 @@
+/**
+ * Return the index within filename from which the extension starts,
+ * handling some common double extensions like .tar.gz, .<ext>.bak, etc
+ *
+ * @param {string} filename - The filaname to get extension index of
+ * @returns {number} the index from which extension starts
+ */
+export function getExtensionIndex(filename) {
+    const doubleExtensions = ['gz', 'xz', 'bz2', 'bak', 'in'];
+    for (let i = filename.length - 1; i >= 0; i--) {
+        if (filename[i] === '.') {
+            const extension = filename.slice(i + 1);
+            if (!doubleExtensions.includes(extension))
+                return i;
+        }
+    }
+    return -1;
+}
+
+/**
+ * Make a filename unique by adding a "(n)" after the name
+ * Increment n if the name is already in the style "<basename> (n).<ext>"
+ *
+ * @param {string} filename - The filaname to make unique
+ * @returns {number} the new filename with "(n)" added/incremented
+ */
+export function makeUnique(filename) {
+    let extension = '';
+    const i = getExtensionIndex(filename);
+    if (i !== -1) {
+        extension = filename.substring(i);
+        filename = filename.substring(0, i);
+    }
+
+    const length = filename.length;
+    if (filename[length - 3] === '(' &&
+        !Number.isNaN(filename[length - 2]) &&
+        filename[length - 1] === ')') {
+        const num = parseInt(filename[length - 2]);
+        return `${filename.substring(0, length - 3)}(${num + 1})${extension}`;
+    } else {
+        return `${filename} (1)${extension}`;
+    }
+}
+

--- a/src/service/utils/filename.js
+++ b/src/service/utils/filename.js
@@ -2,7 +2,7 @@
  * Return the index within filename from which the extension starts,
  * handling some common double extensions like .tar.gz, .<ext>.bak, etc
  *
- * @param {string} filename - The filaname to get extension index of
+ * @param {string} filename - The filename to get extension index of
  * @returns {number} the index from which extension starts
  */
 export function getExtensionIndex(filename) {
@@ -18,11 +18,11 @@ export function getExtensionIndex(filename) {
 }
 
 /**
- * Make a filename unique by adding a "(n)" after the name
+ * Make a filename unique by adding a " (1)" after the name.
  * Increment n if the name is already in the style "<basename> (n).<ext>"
  *
- * @param {string} filename - The filaname to make unique
- * @returns {number} the new filename with "(n)" added/incremented
+ * @param {string} filename - The filename to make unique
+ * @returns {number} the new filename with " (n)" added/incremented
  */
 export function makeUnique(filename) {
     let extension = '';


### PR DESCRIPTION
Added a new file `src/service/utils/filename.js` which has a `makeUnique` function to take in a filename and add a `(1)` after the filename but before the extension. It also handles some common double extensions like `.tar.gz` and `.<ext>.bak` and increments previously added digits at the end, as mentioned [here](https://github.com/GSConnect/gnome-shell-extension-gsconnect/issues/1851#issuecomment-2307536478)

This will fix #1851.

