### PR TITLE
MPRIS: Increase delay for queueing updates

### DIFF
--- a/src/service/plugins/mpris.js
+++ b/src/service/plugins/mpris.js
@@ -284,8 +284,10 @@ const MPRISPlugin = GObject.registerClass({
     _getUpdate(identity, packet) {
 
         const player = this._mpris?.getPlayer(identity);
-        if (!player)
+        if (!player) {
+            debug(`Can't generate update, no such player ID '${identity}'`);
             return;
+        }
 
         const response = {
             type: 'kdeconnect.mpris',
@@ -386,7 +388,7 @@ const MPRISPlugin = GObject.registerClass({
                     requestNowPlaying: true,
                     requestVolume: true,
                 },
-            }, false);
+            });
         }
         this.device.sendPacket(packet);
 
@@ -406,7 +408,7 @@ const MPRISPlugin = GObject.registerClass({
 
         const timer_id = GLib.timeout_add(
             GLib.PRIORITY_DEFAULT,
-            250,  // ms (0.25 seconds)
+            500,  // ms (0.5 seconds)
             this._sendUpdate.bind(this, player)
         );
         this._queueTimers.set(player.Identity, timer_id);


### PR DESCRIPTION
So, it seems I broke VLC in #1950, at least on my incredibly slow, old laptop. (I knew that arbitrary-timeout queueing was gonna go wrong, somehow.) Chrome, where I initially tested that change, works fine. But the timer allows us to catch VLC in a bad state immediately after pausing, which causes the Android controller to no longer be able to unpause a paused player. (We accidentally tell it that VLC `canPlay: false`, so it disables the Pause/Unpause button completely.)

The complete punt of further raising the previous "fix"'s already-arbitrary time delay before sending updates, doubling down on both the arbitrariness and the actual value (from 250ms to 500ms), seems to solve things. At least **for me**, on **my machine**. But since most users are probably on much faster machines where this is less likely to be an issue in the first place, hopefully that's good enough.

### Commit message

In some players (\*cough\* VLC \*cough\*), on slow systems, the transition to paused state after a Pause request causes its canPlay property to return `false` briefly. If our timer fires too quickly, it'll catch the property in that wrong state and disable unpausing the player again.

Doubling the timeout so that we don't accidentally catch the property in the wrong state seems to solve the issue, though if it comes up again we may need to schedule periodic refreshes of the properties just to ensure sanity in the exported state of the players.