### PR TITLE
Share plugin: Make URL auto-opening optional, extend to text-format share requests

### DIFF
--- a/data/org.gnome.Shell.Extensions.GSConnect.gschema.xml
+++ b/data/org.gnome.Shell.Extensions.GSConnect.gschema.xml
@@ -160,6 +160,9 @@ SPDX-License-Identifier: GPL-2.0-or-later
     <key name="receive-directory" type="s">
       <default>""</default>
     </key>
+    <key name="launch-urls" type="b">
+      <default>false</default>
+    </key>
   </schema>
   <schema id="org.gnome.Shell.Extensions.GSConnect.Plugin.SMS">
     <key name="legacy-sms" type="b">

--- a/data/ui/preferences-device-panel.ui
+++ b/data/ui/preferences-device-panel.ui
@@ -327,6 +327,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
                         <property name="position">1</property>
                       </packing>
                     </child>
+                    <!-- SHARING FILES SECTION -->
                     <child>
                       <object class="GtkLabel" id="share-list-label">
                         <property name="visible">True</property>
@@ -351,6 +352,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
                       <object class="GtkGrid" id="share">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
+                        <property name="margin-bottom">32</property>
                         <child>
                           <object class="GtkFrame" id="share-frame">
                             <property name="visible">True</property>
@@ -498,6 +500,119 @@ SPDX-License-Identifier: GPL-2.0-or-later
                         <property name="position">3</property>
                       </packing>
                     </child>
+                    <!-- SHARING LINK SECTION -->
+                    <child>
+                      <object class="GtkLabel" id="links-list-label">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="margin_bottom">12</property>
+                        <property name="label" translatable="yes">Links</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                        </attributes>
+                        <accessibility>
+                          <relation type="label-for" target="links-list"/>
+                        </accessibility>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">4</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkGrid" id="links">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <child>
+                          <object class="GtkFrame" id="links-frame">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label_xalign">0</property>
+                            <child>
+                              <object class="GtkListBox" id="links-list">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="hexpand">True</property>
+                                <property name="selection_mode">none</property>
+                                <signal name="row-activated" handler="_onToggleRowActivated" swapped="no"/>
+                                <signal name="keynav-failed" handler="_onKeynavFailed" swapped="no"/>
+                                <child>
+                                  <object class="GtkListBoxRow" id="links-launch-row">
+                                    <property name="height_request">56</property>
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">True</property>
+                                    <property name="selectable">False</property>
+                                    <child>
+                                      <object class="GtkGrid">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="margin_start">12</property>
+                                        <property name="margin_end">12</property>
+                                        <property name="column_spacing">12</property>
+                                        <child>
+                                          <object class="GtkLabel" id="links-launch-label">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="halign">start</property>
+                                            <property name="valign">center</property>
+                                            <property name="hexpand">True</property>
+                                            <property name="vexpand">True</property>
+                                            <property name="label" translatable="yes">Automatically open received URLs</property>
+                                            <accessibility>
+                                              <relation type="label-for" target="links-launch-row"/>
+                                              <relation type="label-for" target="launch-urls"/>
+                                            </accessibility>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">0</property>
+                                            <property name="top_attach">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkSwitch" id="launch-urls">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="halign">end</property>
+                                            <property name="valign">center</property>
+                                            <property name="action_name">settings.launch-urls</property>
+                                            <accessibility>
+                                              <relation type="controlled-by" target="links-launch-row"/>
+                                              <relation type="labelled-by" target="links-launch-label"/>
+                                            </accessibility>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">1</property>
+                                            <property name="top_attach">0</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                    </child>
+                                    <accessibility>
+                                      <relation type="controller-for" target="launch-urls"/>
+                                      <relation type="labelled-by" target="links-launch-label"/>
+                                    </accessibility>
+                                  </object>
+                                </child>
+                                <accessibility>
+                                  <relation type="labelled-by" target="links-list-label"/>
+                                </accessibility>
+                              </object>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">0</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">5</property>
+                      </packing>
+                    </child>
                   </object>
                 </child>
               </object>
@@ -510,6 +625,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
             <property name="position">1</property>
           </packing>
         </child>
+        <!-- BATTERY PAGE -->
         <child>
           <object class="GtkScrolledWindow" id="battery-page">
             <property name="visible">True</property>

--- a/data/ui/preferences-window.ui
+++ b/data/ui/preferences-window.ui
@@ -82,7 +82,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
     <property name="can_focus">False</property>
     <property name="icon_name">org.gnome.Shell.Extensions.GSConnect-symbolic</property>
     <property name="default_width">640</property>
-    <property name="default_height">460</property>
+    <property name="default_height">550</property>
     <child type="titlebar">
       <object class="GtkHeaderBar" id="headerbar">
         <property name="visible">True</property>

--- a/po/org.gnome.Shell.Extensions.GSConnect.pot
+++ b/po/org.gnome.Shell.Extensions.GSConnect.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.gnome.Shell.Extensions.GSConnect\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-01-03 13:38-0500\n"
+"POT-Creation-Date: 2025-07-11 13:49-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -20,7 +20,7 @@ msgstr ""
 
 #. TRANSLATORS: Extension name
 #: data/metainfo/org.gnome.Shell.Extensions.GSConnect.metainfo.xml.in:12
-#: webextension/gettext.js:30
+#: webextension/gettext.js:29
 msgid "GSConnect"
 msgstr ""
 
@@ -81,7 +81,7 @@ msgstr ""
 msgid "And more…"
 msgstr ""
 
-#: data/metainfo/org.gnome.Shell.Extensions.GSConnect.metainfo.xml.in:141
+#: data/metainfo/org.gnome.Shell.Extensions.GSConnect.metainfo.xml.in:165
 msgid "GSConnect in GNOME Shell"
 msgstr ""
 
@@ -98,8 +98,8 @@ msgstr ""
 #: data/ui/preferences-shortcut-editor.ui:19
 #: data/ui/service-device-chooser.ui:21 data/ui/service-device-chooser.ui:25
 #: data/ui/service-error-dialog.ui:20 data/ui/service-error-dialog.ui:28
-#: src/preferences/service.js:405 src/service/plugins/share.js:161
-#: src/service/plugins/share.js:297 src/service/plugins/share.js:428
+#: src/preferences/service.js:405 src/service/plugins/share.js:179
+#: src/service/plugins/share.js:314 src/service/plugins/share.js:445
 msgid "Cancel"
 msgstr ""
 
@@ -125,20 +125,20 @@ msgid "Type a phone number or name"
 msgstr ""
 
 #. TRANSLATORS: All other phone number types
-#: data/ui/contacts-address-row.ui:71 src/service/ui/contacts.js:149
+#: data/ui/contacts-address-row.ui:71 src/service/ui/contacts.js:158
 msgid "Other"
 msgstr ""
 
 #. TRANSLATORS: Share URL by SMS
-#: data/ui/legacy-messaging-dialog.ui:15 src/service/daemon.js:274
-#: src/service/daemon.js:388 src/service/plugins/sms.js:62
-#: webextension/gettext.js:42
+#: data/ui/legacy-messaging-dialog.ui:15 src/service/daemon.js:333
+#: src/service/daemon.js:447 src/service/plugins/sms.js:62
+#: webextension/gettext.js:41
 msgid "Send SMS"
 msgstr ""
 
 #: data/ui/legacy-messaging-dialog.ui:32 data/ui/legacy-messaging-dialog.ui:36
 #: data/ui/notification-reply-dialog.ui:31
-#: data/ui/notification-reply-dialog.ui:35 src/service/plugins/share.js:429
+#: data/ui/notification-reply-dialog.ui:35 src/service/plugins/share.js:446
 msgid "Send"
 msgstr ""
 
@@ -151,7 +151,7 @@ msgstr ""
 msgid "Send Message"
 msgstr ""
 
-#: data/ui/messaging-conversation.ui:92 src/shell/notification.js:84
+#: data/ui/messaging-conversation.ui:92 src/shell/notification.js:88
 msgid "Type a message"
 msgstr ""
 
@@ -164,12 +164,12 @@ msgid "Type a message and press Enter to send"
 msgstr ""
 
 #: data/ui/messaging-window.ui:21 src/service/plugins/sms.js:30
-#: src/service/ui/messaging.js:1057
+#: src/service/ui/messaging.js:1063
 msgid "Messaging"
 msgstr ""
 
 #: data/ui/messaging-window.ui:30 data/ui/messaging-window.ui:43
-#: src/service/ui/messaging.js:1268
+#: src/service/ui/messaging.js:1274
 msgid "New Conversation"
 msgstr ""
 
@@ -220,7 +220,7 @@ msgstr ""
 msgid "Open"
 msgstr ""
 
-#: data/ui/preferences-device-panel.ui:53 src/preferences/service.js:482
+#: data/ui/preferences-device-panel.ui:53 src/preferences/service.js:504
 msgid "Desktop"
 msgstr ""
 
@@ -240,220 +240,228 @@ msgstr ""
 msgid "Volume Control"
 msgstr ""
 
-#: data/ui/preferences-device-panel.ui:336 src/service/plugins/sftp.js:331
+#: data/ui/preferences-device-panel.ui:337 src/service/plugins/sftp.js:332
 msgid "Files"
 msgstr ""
 
-#: data/ui/preferences-device-panel.ui:388
+#: data/ui/preferences-device-panel.ui:390
 msgid "Receive Files"
 msgstr ""
 
-#: data/ui/preferences-device-panel.ui:447
+#: data/ui/preferences-device-panel.ui:449
 msgid "Save files to"
 msgstr ""
 
-#: data/ui/preferences-device-panel.ui:508
-#: data/ui/preferences-device-panel.ui:2170
+#: data/ui/preferences-device-panel.ui:510
+msgid "Links"
+msgstr ""
+
+#: data/ui/preferences-device-panel.ui:562
+msgid "Automatically open received URLs"
+msgstr ""
+
+#: data/ui/preferences-device-panel.ui:623
+#: data/ui/preferences-device-panel.ui:2286
 msgid "Sharing"
 msgstr ""
 
-#: data/ui/preferences-device-panel.ui:539
+#: data/ui/preferences-device-panel.ui:655
 msgid "Device Battery"
 msgstr ""
 
-#: data/ui/preferences-device-panel.ui:590
+#: data/ui/preferences-device-panel.ui:706
 msgid "Low Battery Notification"
 msgstr ""
 
-#: data/ui/preferences-device-panel.ui:649
+#: data/ui/preferences-device-panel.ui:765
 msgid "Charged Up to Custom Level Notification"
 msgstr ""
 
-#: data/ui/preferences-device-panel.ui:729
+#: data/ui/preferences-device-panel.ui:845
 msgid "Fully Charged Notification"
 msgstr ""
 
-#: data/ui/preferences-device-panel.ui:783
+#: data/ui/preferences-device-panel.ui:899
 msgid "System Battery"
 msgstr ""
 
-#: data/ui/preferences-device-panel.ui:832
+#: data/ui/preferences-device-panel.ui:948
 msgid "Share Statistics"
 msgstr ""
 
-#: data/ui/preferences-device-panel.ui:886
-#: data/ui/preferences-device-panel.ui:2216 src/service/plugins/battery.js:14
+#: data/ui/preferences-device-panel.ui:1002
+#: data/ui/preferences-device-panel.ui:2332 src/service/plugins/battery.js:15
 msgid "Battery"
 msgstr ""
 
-#: data/ui/preferences-device-panel.ui:916
-#: data/ui/preferences-device-panel.ui:1001
-#: data/ui/preferences-device-panel.ui:2262
+#: data/ui/preferences-device-panel.ui:1032
+#: data/ui/preferences-device-panel.ui:1117
+#: data/ui/preferences-device-panel.ui:2378
 #: src/service/plugins/runcommand.js:26 src/service/plugins/runcommand.js:34
 #: src/service/plugins/runcommand.js:194
 msgid "Commands"
 msgstr ""
 
-#: data/ui/preferences-device-panel.ui:975
+#: data/ui/preferences-device-panel.ui:1091
 msgid "Add Command"
 msgstr ""
 
 #. TRANSLATORS: 'Share' is a verb here; this refers to the action of sharing
-#: data/ui/preferences-device-panel.ui:1063
+#: data/ui/preferences-device-panel.ui:1179
 msgid "Share Notifications"
 msgstr ""
 
-#: data/ui/preferences-device-panel.ui:1123
+#: data/ui/preferences-device-panel.ui:1239
 msgid "Share When Active"
 msgstr ""
 
-#: data/ui/preferences-device-panel.ui:1174
+#: data/ui/preferences-device-panel.ui:1290
 msgid "Applications"
 msgstr ""
 
-#: data/ui/preferences-device-panel.ui:1220
-#: data/ui/preferences-device-panel.ui:2308
-#: src/service/plugins/notification.js:17
+#: data/ui/preferences-device-panel.ui:1336
+#: data/ui/preferences-device-panel.ui:2424
+#: src/service/plugins/notification.js:18
 msgid "Notifications"
 msgstr ""
 
-#: data/ui/preferences-device-panel.ui:1278 src/service/plugins/contacts.js:27
+#: data/ui/preferences-device-panel.ui:1394 src/service/plugins/contacts.js:28
 msgid "Contacts"
 msgstr ""
 
-#: data/ui/preferences-device-panel.ui:1331
+#: data/ui/preferences-device-panel.ui:1447
 msgid "Incoming Calls"
 msgstr ""
 
-#: data/ui/preferences-device-panel.ui:1380
-#: data/ui/preferences-device-panel.ui:1547
+#: data/ui/preferences-device-panel.ui:1496
+#: data/ui/preferences-device-panel.ui:1663
 msgid "Volume"
 msgstr ""
 
-#: data/ui/preferences-device-panel.ui:1446
-#: data/ui/preferences-device-panel.ui:1613
+#: data/ui/preferences-device-panel.ui:1562
+#: data/ui/preferences-device-panel.ui:1729
 msgid "Pause Media"
 msgstr ""
 
-#: data/ui/preferences-device-panel.ui:1499
+#: data/ui/preferences-device-panel.ui:1615
 msgid "Ongoing Calls"
 msgstr ""
 
-#: data/ui/preferences-device-panel.ui:1669
+#: data/ui/preferences-device-panel.ui:1785
 msgid "Mute Microphone"
 msgstr ""
 
-#: data/ui/preferences-device-panel.ui:1723
-#: data/ui/preferences-device-panel.ui:2354 src/service/plugins/telephony.js:15
+#: data/ui/preferences-device-panel.ui:1839
+#: data/ui/preferences-device-panel.ui:2470 src/service/plugins/telephony.js:16
 msgid "Telephony"
 msgstr ""
 
-#: data/ui/preferences-device-panel.ui:1758
+#: data/ui/preferences-device-panel.ui:1874
 msgid "Action Shortcuts"
 msgstr ""
 
-#: data/ui/preferences-device-panel.ui:1774
+#: data/ui/preferences-device-panel.ui:1890
 msgid "Reset All…"
 msgstr ""
 
-#: data/ui/preferences-device-panel.ui:1826
+#: data/ui/preferences-device-panel.ui:1942
 msgid "Shortcuts"
 msgstr ""
 
-#: data/ui/preferences-device-panel.ui:1857
+#: data/ui/preferences-device-panel.ui:1973
 msgid "Plugins"
 msgstr ""
 
-#: data/ui/preferences-device-panel.ui:1904
+#: data/ui/preferences-device-panel.ui:2020
 msgid "Experimental"
 msgstr ""
 
-#: data/ui/preferences-device-panel.ui:1951
+#: data/ui/preferences-device-panel.ui:2067
 msgid "Device Cache"
 msgstr ""
 
-#: data/ui/preferences-device-panel.ui:1969
+#: data/ui/preferences-device-panel.ui:2085
 msgid "Clear Cache…"
 msgstr ""
 
-#: data/ui/preferences-device-panel.ui:2008
+#: data/ui/preferences-device-panel.ui:2124
 msgid "Legacy SMS Support"
 msgstr ""
 
-#: data/ui/preferences-device-panel.ui:2065
+#: data/ui/preferences-device-panel.ui:2181
 msgid "SFTP Automount"
 msgstr ""
 
-#: data/ui/preferences-device-panel.ui:2120
-#: data/ui/preferences-device-panel.ui:2446
+#: data/ui/preferences-device-panel.ui:2236
+#: data/ui/preferences-device-panel.ui:2562
 msgid "Advanced"
 msgstr ""
 
-#: data/ui/preferences-device-panel.ui:2400
+#: data/ui/preferences-device-panel.ui:2516
 msgid "Keyboard Shortcuts"
 msgstr ""
 
-#: data/ui/preferences-device-panel.ui:2464
+#: data/ui/preferences-device-panel.ui:2580
 msgid "Device Settings"
 msgstr ""
 
 #. TRANSLATORS: Send a pair request to the device
-#: data/ui/preferences-device-panel.ui:2508
-#: data/ui/preferences-device-panel.ui:2600 src/service/daemon.js:367
+#: data/ui/preferences-device-panel.ui:2624
+#: data/ui/preferences-device-panel.ui:2716 src/service/daemon.js:426
 msgid "Pair"
 msgstr ""
 
-#: data/ui/preferences-device-panel.ui:2540
+#: data/ui/preferences-device-panel.ui:2656
 msgid "Device is unpaired"
 msgstr ""
 
-#: data/ui/preferences-device-panel.ui:2555
+#: data/ui/preferences-device-panel.ui:2671
 msgid "You may configure this device before pairing"
 msgstr ""
 
 #. TRANSLATORS: View the TLS Certificate fingerprint
-#: data/ui/preferences-device-panel.ui:2595 src/preferences/device.js:390
+#: data/ui/preferences-device-panel.ui:2711 src/preferences/device.js:391
 msgid "Encryption Info"
 msgstr ""
 
 #. TRANSLATORS: Unpair the device and notify it
-#: data/ui/preferences-device-panel.ui:2606 src/service/daemon.js:376
+#: data/ui/preferences-device-panel.ui:2722 src/service/daemon.js:435
 msgid "Unpair"
 msgstr ""
 
 #. TRANSLATORS: Send clipboard content to device
-#: data/ui/preferences-device-panel.ui:2618
+#: data/ui/preferences-device-panel.ui:2734
 msgid "To Device"
 msgstr ""
 
 #. TRANSLATORS: Receive clipboard content from the device
-#: data/ui/preferences-device-panel.ui:2624
+#: data/ui/preferences-device-panel.ui:2740
 msgid "From Device"
 msgstr ""
 
 #. TRANSLATORS: Don't change the system volume
-#: data/ui/preferences-device-panel.ui:2636
-#: data/ui/preferences-device-panel.ui:2669
+#: data/ui/preferences-device-panel.ui:2752
+#: data/ui/preferences-device-panel.ui:2785
 msgid "Nothing"
 msgstr ""
 
 #. TRANSLATORS: Restore the system volume
-#: data/ui/preferences-device-panel.ui:2643
-#: data/ui/preferences-device-panel.ui:2676
+#: data/ui/preferences-device-panel.ui:2759
+#: data/ui/preferences-device-panel.ui:2792
 msgid "Restore"
 msgstr ""
 
 #. TRANSLATORS: Lower the system volume
-#: data/ui/preferences-device-panel.ui:2650
-#: data/ui/preferences-device-panel.ui:2683
+#: data/ui/preferences-device-panel.ui:2766
+#: data/ui/preferences-device-panel.ui:2799
 msgid "Lower"
 msgstr ""
 
 #. TRANSLATORS: Mute the system volume
 #. TRANSLATORS: Silence the actively ringing call
-#: data/ui/preferences-device-panel.ui:2657
-#: data/ui/preferences-device-panel.ui:2690
-#: src/service/plugins/telephony.js:197
+#: data/ui/preferences-device-panel.ui:2773
+#: data/ui/preferences-device-panel.ui:2806
+#: src/service/plugins/telephony.js:198
 msgid "Mute"
 msgstr ""
 
@@ -478,7 +486,7 @@ msgstr ""
 msgid "Refresh"
 msgstr ""
 
-#: data/ui/preferences-window.ui:139 src/extension.js:114
+#: data/ui/preferences-window.ui:139 src/extension.js:113
 msgid "Mobile Settings"
 msgstr ""
 
@@ -498,7 +506,7 @@ msgstr ""
 msgid "Devices"
 msgstr ""
 
-#: data/ui/preferences-window.ui:328 src/preferences/service.js:644
+#: data/ui/preferences-window.ui:328 src/preferences/service.js:666
 msgid "Searching for devices…"
 msgstr ""
 
@@ -522,7 +530,7 @@ msgstr ""
 msgid "This device is invisible to unpaired devices"
 msgstr ""
 
-#: data/ui/preferences-window.ui:772 src/service/manager.js:144
+#: data/ui/preferences-window.ui:772 src/service/manager.js:163
 msgid "Discovery Disabled"
 msgstr ""
 
@@ -563,7 +571,7 @@ msgid "Select"
 msgstr ""
 
 #. TRANSLATORS: No devices are known or available
-#: data/ui/service-device-chooser.ui:101 webextension/gettext.js:38
+#: data/ui/service-device-chooser.ui:101 webextension/gettext.js:37
 msgid "No Device Found"
 msgstr ""
 
@@ -593,37 +601,37 @@ msgstr ""
 #. context menu
 #. TRANSLATORS: A phone number (eg. "Send to 555-5555")
 #. Update UI
-#: nautilus-extension/nautilus-gsconnect.py:187 src/service/ui/contacts.js:509
-#: src/service/ui/contacts.js:524
+#: nautilus-extension/nautilus-gsconnect.py:187 src/service/ui/contacts.js:518
+#: src/service/ui/contacts.js:533
 #, python-format, javascript-format
 msgid "Send to %s"
 msgstr ""
 
 #. TRANSLATORS: Top-level context menu item for GSConnect
-#: nautilus-extension/nautilus-gsconnect.py:195 webextension/gettext.js:34
+#: nautilus-extension/nautilus-gsconnect.py:195 webextension/gettext.js:33
 msgid "Send To Mobile Device"
 msgstr ""
 
-#: src/extension.js:50
+#: src/extension.js:49
 msgid "Sync between your devices"
 msgstr ""
 
-#: src/extension.js:159
+#: src/extension.js:158
 #, javascript-format
 msgid "%d Connected"
 msgid_plural "%d Connected"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/preferences/device.js:669 src/preferences/device.js:675
+#: src/preferences/device.js:671 src/preferences/device.js:677
 msgid "Edit"
 msgstr ""
 
-#: src/preferences/device.js:684 src/preferences/device.js:690
+#: src/preferences/device.js:686 src/preferences/device.js:692
 msgid "Remove"
 msgstr ""
 
-#: src/preferences/device.js:944 src/preferences/device.js:972
+#: src/preferences/device.js:946 src/preferences/device.js:974
 msgid "Disabled"
 msgstr ""
 
@@ -660,117 +668,139 @@ msgstr ""
 msgid "Review Log"
 msgstr ""
 
-#: src/preferences/service.js:474
+#: src/preferences/service.js:431
+msgid "Invalid Device Name"
+msgstr ""
+
+#. TRANSLATOR: %s is a list of forbidden characters
+#: src/preferences/service.js:433
+#, javascript-format
+msgid ""
+"Device name must not contain any of %s and have a length of 1-32 characters"
+msgstr ""
+
+#: src/preferences/service.js:496
 msgid "Laptop"
 msgstr ""
 
-#: src/preferences/service.js:476
+#: src/preferences/service.js:498
 msgid "Smartphone"
 msgstr ""
 
-#: src/preferences/service.js:478
+#: src/preferences/service.js:500
 msgid "Tablet"
 msgstr ""
 
-#: src/preferences/service.js:480
+#: src/preferences/service.js:502
 msgid "Television"
 msgstr ""
 
-#: src/preferences/service.js:502
+#: src/preferences/service.js:524
 msgid "Unpaired"
 msgstr ""
 
-#: src/preferences/service.js:506
+#: src/preferences/service.js:528
 msgid "Disconnected"
 msgstr ""
 
-#: src/preferences/service.js:510
+#: src/preferences/service.js:532
 msgid "Connected"
 msgstr ""
 
-#: src/preferences/service.js:646
+#: src/preferences/service.js:668
 msgid "Waiting for service…"
 msgstr ""
 
-#: src/service/daemon.js:175
+#. Notify the user
+#: src/service/daemon.js:94
+msgid "Settings Migrated"
+msgstr ""
+
+#: src/service/daemon.js:95
+msgid ""
+"GSConnect has updated to support changes to the KDE Connect protocol. Some "
+"devices may need to be repaired."
+msgstr ""
+
+#: src/service/daemon.js:231
 msgid "Click for help troubleshooting"
 msgstr ""
 
-#: src/service/daemon.js:186
+#: src/service/daemon.js:242
 msgid "Click for more information"
 msgstr ""
 
-#: src/service/daemon.js:280
+#: src/service/daemon.js:339
 msgid "Dial Number"
 msgstr ""
 
-#: src/service/daemon.js:286 src/service/daemon.js:475
+#: src/service/daemon.js:345 src/service/daemon.js:534
 #: src/service/plugins/share.js:31
 msgid "Share File"
 msgstr ""
 
-#: src/service/daemon.js:337
+#: src/service/daemon.js:396
 msgid "List available devices"
 msgstr ""
 
-#: src/service/daemon.js:346
+#: src/service/daemon.js:405
 msgid "List all devices"
 msgstr ""
 
-#: src/service/daemon.js:355
+#: src/service/daemon.js:414
 msgid "Target Device"
 msgstr ""
 
-#: src/service/daemon.js:397
+#: src/service/daemon.js:456
 msgid "Message Body"
 msgstr ""
 
-#: src/service/daemon.js:409 src/service/plugins/notification.js:56
+#: src/service/daemon.js:468 src/service/plugins/notification.js:57
 msgid "Send Notification"
 msgstr ""
 
-#: src/service/daemon.js:418
+#: src/service/daemon.js:477
 msgid "Notification App Name"
 msgstr ""
 
-#: src/service/daemon.js:427
+#: src/service/daemon.js:486
 msgid "Notification Body"
 msgstr ""
 
-#: src/service/daemon.js:436
+#: src/service/daemon.js:495
 msgid "Notification Icon"
 msgstr ""
 
-#: src/service/daemon.js:445
+#: src/service/daemon.js:504
 msgid "Notification ID"
 msgstr ""
 
-#: src/service/daemon.js:454 src/service/plugins/ping.js:13
+#: src/service/daemon.js:513 src/service/plugins/ping.js:13
 #: src/service/plugins/ping.js:20 src/service/plugins/ping.js:47
 msgid "Ping"
 msgstr ""
 
-#: src/service/daemon.js:463 src/service/plugins/battery.js:246
-#: src/service/plugins/battery.js:275 src/service/plugins/battery.js:304
+#: src/service/daemon.js:522 src/service/plugins/battery.js:247
+#: src/service/plugins/battery.js:276 src/service/plugins/battery.js:305
 #: src/service/plugins/findmyphone.js:22
 msgid "Ring"
 msgstr ""
 
-#: src/service/daemon.js:484 src/service/plugins/share.js:47
-#: src/service/ui/messaging.js:1251 src/service/ui/messaging.js:1259
+#: src/service/daemon.js:543 src/service/plugins/share.js:47
+#: src/service/ui/messaging.js:1257 src/service/ui/messaging.js:1265
 msgid "Share Link"
 msgstr ""
 
-#: src/service/daemon.js:493 src/service/plugins/share.js:39
+#: src/service/daemon.js:552 src/service/plugins/share.js:39
 msgid "Share Text"
 msgstr ""
 
-#: src/service/daemon.js:505
+#: src/service/daemon.js:564
 msgid "Show release version"
 msgstr ""
 
 #. TRANSLATORS: Bluetooth address for remote device
-#: src/service/device.js:171
+#: src/service/device.js:195
 #, javascript-format
 msgid "Bluetooth device at %s"
 msgstr ""
@@ -780,74 +810,84 @@ msgstr ""
 #. Example:
 #.
 #. Verification key: 0123456789abcdef000000000000000000000000
-#: src/service/device.js:212
+#: src/service/device.js:223
 #, javascript-format
 msgid "Verification key: %s"
 msgstr ""
 
 #. TRANSLATORS: eg. Pair Request from Google Pixel
-#: src/service/device.js:846
+#: src/service/device.js:862
 #, javascript-format
 msgid "Pair Request from %s"
 msgstr ""
 
-#: src/service/device.js:853
+#: src/service/device.js:869
 msgid "Reject"
 msgstr ""
 
-#: src/service/device.js:858
+#: src/service/device.js:874
 msgid "Accept"
 msgstr ""
 
-#: src/service/manager.js:145
+#. TRANSLATORS: eg. Failed to pair with Google Pixel
+#: src/service/device.js:960
+#, javascript-format
+msgid "Failed to pair with %s"
+msgstr ""
+
+#: src/service/device.js:961
+msgid "Device clocks are out of sync"
+msgstr ""
+
+#: src/service/init.js:347
+msgid "OpenSSL not found"
+msgstr ""
+
+#: src/service/manager.js:164
 msgid ""
 "Discovery has been disabled due to the number of devices on this network."
 msgstr ""
 
-#: src/service/backends/lan.js:177
-msgid "OpenSSL not found"
-msgstr ""
-
-#: src/service/backends/lan.js:470
+#: src/service/backends/lan.js:477
 msgid "Port already in use"
 msgstr ""
 
-#: src/service/plugins/battery.js:15
+#: src/service/plugins/battery.js:16
 msgid "Exchange battery information"
 msgstr ""
 
 #. TRANSLATORS: eg. Google Pixel: Battery is full
-#: src/service/plugins/battery.js:255
+#: src/service/plugins/battery.js:256
 #, javascript-format
 msgid "%s: Battery is full"
 msgstr ""
 
 #. TRANSLATORS: when the battery is fully charged
 #. TRANSLATORS: When the battery level is 100%
-#: src/service/plugins/battery.js:257 src/shell/device.js:119
+#: src/service/plugins/battery.js:258 src/shell/device.js:119
 msgid "Fully Charged"
 msgstr ""
 
 #. TRANSLATORS: eg. Google Pixel: Battery has reached custom charge level
-#: src/service/plugins/battery.js:284
+#: src/service/plugins/battery.js:285
 #, javascript-format
 msgid "%s: Battery has reached custom charge level"
 msgstr ""
 
 #. TRANSLATORS: when the battery has reached custom charge level
-#: src/service/plugins/battery.js:286
+#: src/service/plugins/battery.js:287
 #, javascript-format
 msgid "%d%% Charged"
 msgstr ""
 
 #. TRANSLATORS: eg. Google Pixel: Battery is low
-#: src/service/plugins/battery.js:313
+#: src/service/plugins/battery.js:314
 #, javascript-format
 msgid "%s: Battery is low"
 msgstr ""
 
 #. TRANSLATORS: eg. 15% remaining
-#: src/service/plugins/battery.js:315
+#: src/service/plugins/battery.js:316
 #, javascript-format
 msgid "%d%% remaining"
 msgstr ""
@@ -868,8 +908,17 @@ msgstr ""
 msgid "Clipboard Pull"
 msgstr ""
 
-#: src/service/plugins/contacts.js:28
+#: src/service/plugins/contacts.js:29
 msgid "Access contacts of the paired device"
+msgstr ""
+
+#. Ensure we have a sender
+#. TRANSLATORS: No name or phone number
+#. Contact Name
+#: src/service/plugins/contacts.js:242 src/service/plugins/contacts.js:362
+#: src/service/plugins/telephony.js:156 src/service/plugins/telephony.js:175
+#: src/service/ui/contacts.js:620 src/service/ui/messaging.js:756
+msgid "Unknown Contact"
 msgstr ""
 
 #: src/service/plugins/findmyphone.js:15
@@ -892,35 +941,35 @@ msgstr ""
 msgid "Remote Input"
 msgstr ""
 
-#: src/service/plugins/mpris.js:17
+#: src/service/plugins/mpris.js:18
 msgid "MPRIS"
 msgstr ""
 
-#: src/service/plugins/mpris.js:18
+#: src/service/plugins/mpris.js:19
 msgid "Bidirectional remote media playback control"
 msgstr ""
 
-#: src/service/plugins/mpris.js:329
+#: src/service/plugins/mpris.js:355
 msgid "Unknown"
 msgstr ""
 
-#: src/service/plugins/notification.js:18
+#: src/service/plugins/notification.js:19
 msgid "Share notifications with the paired device"
 msgstr ""
 
-#: src/service/plugins/notification.js:32
+#: src/service/plugins/notification.js:33
 msgid "Cancel Notification"
 msgstr ""
 
-#: src/service/plugins/notification.js:40
+#: src/service/plugins/notification.js:41
 msgid "Close Notification"
 msgstr ""
 
-#: src/service/plugins/notification.js:48
+#: src/service/plugins/notification.js:49
 msgid "Reply Notification"
 msgstr ""
 
-#: src/service/plugins/notification.js:64
+#: src/service/plugins/notification.js:65
 msgid "Activate Notification"
 msgstr ""
 
@@ -953,23 +1002,23 @@ msgid ""
 "on this PC"
 msgstr ""
 
-#: src/service/plugins/sftp.js:14
+#: src/service/plugins/sftp.js:15
 msgid "SFTP"
 msgstr ""
 
-#: src/service/plugins/sftp.js:16
+#: src/service/plugins/sftp.js:17
 msgid "Browse the paired device filesystem"
 msgstr ""
 
-#: src/service/plugins/sftp.js:21
+#: src/service/plugins/sftp.js:22
 msgid "Mount"
 msgstr ""
 
-#: src/service/plugins/sftp.js:29
+#: src/service/plugins/sftp.js:30
 msgid "Unmount"
 msgstr ""
 
-#: src/service/plugins/sftp.js:190
+#: src/service/plugins/sftp.js:191
 #, javascript-format
 msgid "%s reported an error"
 msgstr ""
@@ -982,87 +1031,87 @@ msgstr ""
 msgid "Share files and URLs between devices"
 msgstr ""
 
-#: src/service/plugins/share.js:130 src/service/plugins/share.js:209
-#: src/service/plugins/share.js:320
+#: src/service/plugins/share.js:148 src/service/plugins/share.js:227
+#: src/service/plugins/share.js:337
 msgid "Transfer Failed"
 msgstr ""
 
 #. TRANSLATORS: eg. Google Pixel is not allowed to upload files
-#: src/service/plugins/share.js:132
+#: src/service/plugins/share.js:150
 #, javascript-format
 msgid "%s is not allowed to upload files"
 msgstr ""
 
-#: src/service/plugins/share.js:154 src/service/plugins/share.js:290
+#: src/service/plugins/share.js:172 src/service/plugins/share.js:307
 msgid "Transferring File"
 msgstr ""
 
 #. TRANSLATORS: eg. Receiving 'book.pdf' from Google Pixel
-#: src/service/plugins/share.js:156
+#: src/service/plugins/share.js:174
 #, javascript-format
 msgid "Receiving “%s” from %s"
 msgstr ""
 
-#: src/service/plugins/share.js:175 src/service/plugins/share.js:310
+#: src/service/plugins/share.js:193 src/service/plugins/share.js:327
 msgid "Transfer Successful"
 msgstr ""
 
 #. TRANSLATORS: eg. Received 'book.pdf' from Google Pixel
-#: src/service/plugins/share.js:177
+#: src/service/plugins/share.js:195
 #, javascript-format
 msgid "Received “%s” from %s"
 msgstr ""
 
-#: src/service/plugins/share.js:187
+#: src/service/plugins/share.js:205
 msgid "Show File Location"
 msgstr ""
 
-#: src/service/plugins/share.js:192
+#: src/service/plugins/share.js:210
 msgid "Open File"
 msgstr ""
 
 #. TRANSLATORS: eg. Failed to receive 'book.pdf' from Google Pixel
-#: src/service/plugins/share.js:211
+#: src/service/plugins/share.js:229
 #, javascript-format
 msgid "Failed to receive “%s” from %s"
 msgstr ""
 
-#: src/service/plugins/share.js:242
+#: src/service/plugins/share.js:259
 #, javascript-format
 msgid "Text Shared By %s"
 msgstr ""
 
 #. TRANSLATORS: eg. Sending 'book.pdf' to Google Pixel
-#: src/service/plugins/share.js:292
+#: src/service/plugins/share.js:309
 #, javascript-format
 msgid "Sending “%s” to %s"
 msgstr ""
 
 #. TRANSLATORS: eg. Sent "book.pdf" to Google Pixel
-#: src/service/plugins/share.js:312
+#: src/service/plugins/share.js:329
 #, javascript-format
 msgid "Sent “%s” to %s"
 msgstr ""
 
 #. TRANSLATORS: eg. Failed to send "book.pdf" to Google Pixel
-#: src/service/plugins/share.js:322
+#: src/service/plugins/share.js:339
 #, javascript-format
 msgid "Failed to send “%s” to %s"
 msgstr ""
 
 #. TRANSLATORS: eg. Send files to Google Pixel
-#: src/service/plugins/share.js:380
+#: src/service/plugins/share.js:397
 #, javascript-format
 msgid "Send files to %s"
 msgstr ""
 
 #. TRANSLATORS: Mark the file to be opened once completed
-#: src/service/plugins/share.js:384
+#: src/service/plugins/share.js:401
 msgid "Open when done"
 msgstr ""
 
 #. TRANSLATORS: eg. Send a link to Google Pixel
-#: src/service/plugins/share.js:423
+#: src/service/plugins/share.js:440
 #, javascript-format
 msgid "Send a link to %s"
 msgstr ""
@@ -1087,63 +1136,55 @@ msgstr ""
 msgid "Share SMS"
 msgstr ""
 
-#: src/service/plugins/systemvolume.js:13
+#: src/service/plugins/systemvolume.js:27
 msgid "System Volume"
 msgstr ""
 
-#: src/service/plugins/systemvolume.js:14
+#: src/service/plugins/systemvolume.js:28
 msgid "Enable the paired device to control the system volume"
 msgstr ""
 
-#: src/service/plugins/systemvolume.js:58
+#: src/service/plugins/systemvolume.js:72
 msgid "PulseAudio not found"
 msgstr ""
 
-#: src/service/plugins/telephony.js:16
+#: src/service/plugins/telephony.js:17
 msgid ""
 "Be notified about calls and adjust system volume during ringing/ongoing calls"
 msgstr ""
 
 #. TRANSLATORS: Silence the actively ringing call
-#: src/service/plugins/telephony.js:28
+#: src/service/plugins/telephony.js:29
 msgid "Mute Call"
 msgstr ""
 
-#. Ensure we have a sender
-#. TRANSLATORS: No name or phone number
-#. Contact Name
-#: src/service/plugins/telephony.js:155 src/service/plugins/telephony.js:174
-#: src/service/ui/contacts.js:611 src/service/ui/messaging.js:750
-msgid "Unknown Contact"
-msgstr ""
-
 #. TRANSLATORS: The phone is ringing
-#: src/service/plugins/telephony.js:193
+#: src/service/plugins/telephony.js:194
 msgid "Incoming call"
 msgstr ""
 
 #. TRANSLATORS: A phone call is active
-#: src/service/plugins/telephony.js:208
+#: src/service/plugins/telephony.js:209
 msgid "Ongoing call"
 msgstr ""
 
 #. TRANSLATORS: A fax number
-#: src/service/ui/contacts.js:134
+#: src/service/ui/contacts.js:143
 msgid "Fax"
 msgstr ""
 
 #. TRANSLATORS: A work or office phone number
-#: src/service/ui/contacts.js:138
+#: src/service/ui/contacts.js:147
 msgid "Work"
 msgstr ""
 
 #. TRANSLATORS: A mobile or cellular phone number
-#: src/service/ui/contacts.js:142
+#: src/service/ui/contacts.js:151
 msgid "Mobile"
 msgstr ""
 
 #. TRANSLATORS: A home phone number
-#: src/service/ui/contacts.js:146
+#: src/service/ui/contacts.js:155
 msgid "Home"
 msgstr ""
 
@@ -1165,21 +1206,21 @@ msgid_plural "%d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/service/ui/messaging.js:401
+#: src/service/ui/messaging.js:407
 msgid "Not available"
 msgstr ""
 
-#: src/service/ui/messaging.js:758
+#: src/service/ui/messaging.js:764
 msgid "Group Message"
 msgstr ""
 
 #. TRANSLATORS: An outgoing message body in a conversation summary
-#: src/service/ui/messaging.js:773
+#: src/service/ui/messaging.js:779
 #, javascript-format
 msgid "You: %s"
 msgstr ""
 
-#: src/service/ui/messaging.js:959
+#: src/service/ui/messaging.js:965
 #, javascript-format
 msgid "And %d other contact"
 msgid_plural "And %d others"
@@ -1213,21 +1254,21 @@ msgstr ""
 msgid "%d%% (%d∶%02d Remaining)"
 msgstr ""
 
-#: src/shell/notification.js:69
+#: src/shell/notification.js:73
 msgid "Reply"
 msgstr ""
 
 #. TRANSLATORS: Chrome/Firefox WebExtension description
-#: webextension/gettext.js:32
+#: webextension/gettext.js:31
 msgid "Share links with GSConnect, direct to the browser or by SMS."
 msgstr ""
 
 #. TRANSLATORS: WebExtension can't connect to GSConnect
-#: webextension/gettext.js:36
+#: webextension/gettext.js:35
 msgid "Service Unavailable"
 msgstr ""
 
 #. TRANSLATORS: Open URL with the device's browser
-#: webextension/gettext.js:40
+#: webextension/gettext.js:39
 msgid "Open in Browser"
 msgstr ""

--- a/src/preferences/device.js
+++ b/src/preferences/device.js
@@ -267,6 +267,7 @@ export const Panel = GObject.registerClass({
         'sharing', 'sharing-page',
         'desktop-list', 'clipboard', 'clipboard-sync', 'mousepad', 'mpris', 'systemvolume',
         'share', 'share-list', 'receive-files', 'receive-directory',
+        'links', 'links-list', 'launch-urls',
 
         // Battery
         'battery',
@@ -467,6 +468,7 @@ export const Panel = GObject.registerClass({
 
         settings = this.pluginSettings('share');
         this.actions.add_action(settings.create_action('receive-files'));
+        this.actions.add_action(settings.create_action('launch-urls'));
 
         settings = this.pluginSettings('sms');
         this.actions.add_action(settings.create_action('legacy-sms'));

--- a/src/service/plugins/share.js
+++ b/src/service/plugins/share.js
@@ -84,9 +84,9 @@ const SharePlugin = GObject.registerClass({
         }
         const message = text || url;
         if (message === undefined)
-            throw new Error("Share request has invalid payload, ignoring.");
+            throw new Error('Share request has invalid payload, ignoring.');
 
-        const url_start = message.toLowerCase().lastIndexOf("http");
+        const url_start = message.toLowerCase().lastIndexOf('http');
         if (this.settings.get_boolean('launch-urls') && url_start >= 0) {
             const shared_url = message.slice(url_start);
             debug(`Launching shared URL "${shared_url}".`);
@@ -94,7 +94,7 @@ const SharePlugin = GObject.registerClass({
             return;
         }
 
-        debug("Displaying shared message.");
+        debug('Displaying shared message.');
         this._handleText(message);
     }
 


### PR DESCRIPTION
The KDE Connect app's ability to open web content on a paired desktop has always been a bit spotty. Most of the time, sharing a page from a browser app would work fine — the URL would be sent along as a `kdeconnect.share.request.body.uri` and open automatically. But some apps would only ever share links as `kdeconnect.share.request.body.text` content that would come up in a dialog, and require clicking the embedded URL to load it.

Since my phone upgraded to Android 15, **every** link I share to my desktop, from **every** app (even Chrome) comes through as a text share in this form:

> Page title or other 'rich' content https://finally/the/url/at/the/end

Which means that every time I try to open some page in my desktop browser, I have to also find and click the link in the dialog that comes up before it will load.

Well, no more.

This PR **extends auto-launching of URLs in `kdeconnect.share.request` packets to BOTH the `text` and `uri` payload** (If `uri` is even still used anymore; I'm not sure it is.) 

And because some users may not appreciate their textual shares opening without their participation just because they contain a link, **it also adds a new preference (default _DISABLED_) to control the auto-launching behavior.**

So, yes, this PR will turn off GSConnect's automatic web-page launching for all users. But there's a preference to re-enable it, for those who still want that functionality. And if they do enable it, it'll work for more types of shares.

When "Automatically open shared URLs" is switched on in the Device > Share > Link settings (the "Link" section is new, and the switch there controls a new `share.launch-urls` boolean per-device setting), then any `uri` **OR** `text` share request containing a link will auto-launch the link instead of displaying a dialog. (Even if the text share contains other content.)

When that setting is turned off (the new default), all (non-file) share requests will be displayed in a dialog. Even requests that contain only a `uri`. (Those are the ones that previously were hardcoded to always auto-launch. Users previously had no control over that behavior except to disable the Share plugin entirely.)