### PR TITLE
Version bump for the development tree

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,7 @@
 
 project('gsconnect',
   'c',
-  version: '66',
+  version: '67',
   meson_version: '>= 0.59.0',
 )
 


### PR DESCRIPTION
One thing I neglected to do, when rolling the latest releases, was bump the `main` branch version to be higher than the latest release (`v66`). So, `main` is now on version `67`.
