### PR TITLE
Missing dependency banner

### DIFF
--- a/data/org.gnome.Shell.Extensions.GSConnect.gschema.xml
+++ b/data/org.gnome.Shell.Extensions.GSConnect.gschema.xml
@@ -38,6 +38,9 @@ SPDX-License-Identifier: GPL-2.0-or-later
     <key name="discoverable" type="b">
       <default>true</default>
     </key>
+    <key name="missing-openssl" type="b">
+      <default>false</default>
+    </key>
   </schema>
 
   <!-- Window Geometry -->

--- a/data/ui/preferences-window.ui
+++ b/data/ui/preferences-window.ui
@@ -723,21 +723,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
                         <child>
                           <placeholder/>
                         </child>
-                        <child>
-                          <object class="GtkButton">
-                            <property name="label" translatable="yes">Enable</property>
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="action_name">win.discoverable</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">2</property>
-                          </packing>
-                        </child>
-                      </object>
+                       </object>
                       <packing>
                         <property name="expand">False</property>
                         <property name="fill">True</property>
@@ -821,6 +807,20 @@ SPDX-License-Identifier: GPL-2.0-or-later
                         <child>
                           <placeholder/>
                         </child>
+                        <child>
+                          <object class="GtkButton">
+                            <property name="label" translatable="yes">Retry</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <signal name="clicked" handler="_onRetryOpenssl" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">2</property>
+                          </packing>
+                        </child>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -842,7 +842,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
                                 <property name="label" translatable="yes">The &lt;tt&gt;openssl&lt;/tt&gt; command-line tool does not appear to be installed.
-Use your distro's package manager to install it, then restart or log out and back in.
+Use your distro's package manager to install it.
 For more information, visit &lt;a href="https://github.com/gsconect/gnome-shell-extension-gsconnect/wiki/Error#OpenSSL"&gt;the GSConnect wiki&lt;/a&gt;.</property>
                                 <property name="use-markup">True</property>
                                 <property name="track-visited-links">True</property>

--- a/data/ui/preferences-window.ui
+++ b/data/ui/preferences-window.ui
@@ -838,11 +838,13 @@ SPDX-License-Identifier: GPL-2.0-or-later
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <child>
-                              <object class="GtkLabel" id="openssl_message">
+                              <object class="GtkLabel">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
-                                <property name="wrap">True</property>
-                                <property name="max-width-chars">100</property>
+                                <property name="label" translatable="yes">The &lt;tt&gt;openssl&lt;/tt&gt; command-line tool does not appear to be installed.
+Use your distro's package manager to install it, then restart or log out and back in.
+For more information, visit &lt;a href="https://github.com/gsconect/gnome-shell-extension-gsconnect/wiki/Error#OpenSSL"&gt;the GSConnect wiki&lt;/a&gt;.</property>
+                                <property name="use-markup">True</property>
                                 <property name="track-visited-links">True</property>
                               </object>
                               <packing>

--- a/data/ui/preferences-window.ui
+++ b/data/ui/preferences-window.ui
@@ -701,11 +701,11 @@ SPDX-License-Identifier: GPL-2.0-or-later
               </object>
               <packing>
                 <property name="left_attach">0</property>
-                <property name="top_attach">1</property>
+                <property name="top_attach">2</property>
               </packing>
             </child>
             <child>
-              <object class="GtkRevealer" id="infobar">
+              <object class="GtkRevealer" id="infobar_discoverable">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <child>
@@ -799,6 +799,92 @@ SPDX-License-Identifier: GPL-2.0-or-later
               <packing>
                 <property name="left_attach">0</property>
                 <property name="top_attach">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkRevealer" id="infobar_openssl">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <child>
+                  <object class="GtkInfoBar">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="message-type">warning</property>
+                    <child internal-child="action_area">
+                      <object class="GtkButtonBox">
+                        <property name="can_focus">False</property>
+                        <property name="spacing">6</property>
+                        <property name="layout_style">end</property>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child internal-child="content_area">
+                      <object class="GtkBox">
+                        <property name="can_focus">False</property>
+                        <property name="orientation">vertical</property>
+                        <property name="spacing">12</property>
+                        <child>
+                          <object class="GtkGrid">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <child>
+                              <object class="GtkLabel" id="openssl_message">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="wrap">True</property>
+                                <property name="max-width-chars">100</property>
+                                <property name="track-visited-links">True</property>
+                              </object>
+                              <packing>
+                                <property name="left_attach">0</property>
+                                <property name="top_attach">1</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="halign">start</property>
+                                <property name="label" translatable="yes">OpenSSL Missing</property>
+                                <attributes>
+                                  <attribute name="weight" value="bold"/>
+                                </attributes>
+                              </object>
+                              <packing>
+                                <property name="left_attach">0</property>
+                                <property name="top_attach">0</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">1</property>
               </packing>
             </child>
           </object>

--- a/data/ui/preferences-window.ui
+++ b/data/ui/preferences-window.ui
@@ -855,7 +855,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="halign">start</property>
-                                <property name="label" translatable="yes">OpenSSL Missing</property>
+                                <property name="label" translatable="yes">OpenSSL not found</property>
                                 <attributes>
                                   <attribute name="weight" value="bold"/>
                                 </attributes>

--- a/po/org.gnome.Shell.Extensions.GSConnect.pot
+++ b/po/org.gnome.Shell.Extensions.GSConnect.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.gnome.Shell.Extensions.GSConnect\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-29 15:28-0400\n"
+"POT-Creation-Date: 2025-08-29 15:54-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -534,8 +534,8 @@ msgstr ""
 msgid "Discovery Disabled"
 msgstr ""
 
-#: data/ui/preferences-window.ui:858
-msgid "OpenSSL Missing"
+#: data/ui/preferences-window.ui:858 src/service/init.js:349
+msgid "OpenSSL not found"
 msgstr ""
 
 #. TRANSLATORS: Open a dialog to connect to an IP or Bluez device
@@ -851,10 +851,6 @@ msgstr ""
 
 #: src/service/device.js:961
 msgid "Device clocks are out of sync"
-msgstr ""
-
-#: src/service/init.js:349
-msgid "OpenSSL not found"
 msgstr ""
 
 #: src/service/manager.js:173

--- a/po/org.gnome.Shell.Extensions.GSConnect.pot
+++ b/po/org.gnome.Shell.Extensions.GSConnect.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.gnome.Shell.Extensions.GSConnect\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-29 15:54-0400\n"
+"POT-Creation-Date: 2025-09-01 00:55-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -98,7 +98,7 @@ msgstr ""
 #: data/ui/preferences-shortcut-editor.ui:19
 #: data/ui/service-device-chooser.ui:21 data/ui/service-device-chooser.ui:25
 #: data/ui/service-error-dialog.ui:20 data/ui/service-error-dialog.ui:28
-#: src/preferences/service.js:426 src/service/plugins/share.js:179
+#: src/preferences/service.js:417 src/service/plugins/share.js:179
 #: src/service/plugins/share.js:314 src/service/plugins/share.js:445
 msgid "Cancel"
 msgstr ""
@@ -116,7 +116,7 @@ msgid "No contacts"
 msgstr ""
 
 #: data/ui/contact-chooser.ui:68 data/ui/messaging-window.ui:103
-#: data/ui/mousepad-input-dialog.ui:56 data/ui/preferences-window.ui:933
+#: data/ui/mousepad-input-dialog.ui:56 data/ui/preferences-window.ui:935
 msgid "Help"
 msgstr ""
 
@@ -220,7 +220,7 @@ msgstr ""
 msgid "Open"
 msgstr ""
 
-#: data/ui/preferences-device-panel.ui:53 src/preferences/service.js:525
+#: data/ui/preferences-device-panel.ui:53 src/preferences/service.js:516
 msgid "Desktop"
 msgstr ""
 
@@ -506,7 +506,7 @@ msgstr ""
 msgid "Devices"
 msgstr ""
 
-#: data/ui/preferences-window.ui:328 src/preferences/service.js:687
+#: data/ui/preferences-window.ui:328 src/preferences/service.js:678
 msgid "Searching for devices…"
 msgstr ""
 
@@ -534,35 +534,44 @@ msgstr ""
 msgid "Discovery Disabled"
 msgstr ""
 
-#: data/ui/preferences-window.ui:858 src/service/init.js:349
+#: data/ui/preferences-window.ui:844
+msgid ""
+"The <tt>openssl</tt> command-line tool does not appear to be installed.\n"
+"Use your distro's package manager to install it, then restart or log out and "
+"back in.\n"
+"For more information, visit <a href=\"https://github.com/gsconect/gnome-"
+"shell-extension-gsconnect/wiki/Error#OpenSSL\">the GSConnect wiki</a>."
+msgstr ""
+
+#: data/ui/preferences-window.ui:860 src/service/init.js:349
 msgid "OpenSSL not found"
 msgstr ""
 
 #. TRANSLATORS: Open a dialog to connect to an IP or Bluez device
-#: data/ui/preferences-window.ui:907
+#: data/ui/preferences-window.ui:909
 msgid "Add device by IP…"
 msgstr ""
 
-#: data/ui/preferences-window.ui:912
+#: data/ui/preferences-window.ui:914
 msgid "Display Mode"
 msgstr ""
 
 #. TRANSLATORS: Show device indicators in the top bar
-#: data/ui/preferences-window.ui:915
+#: data/ui/preferences-window.ui:917
 msgid "Panel"
 msgstr ""
 
 #. TRANSLATORS: Show devices in the user menu like Bluetooth
-#: data/ui/preferences-window.ui:921
+#: data/ui/preferences-window.ui:923
 msgid "User Menu"
 msgstr ""
 
 #. TRANSLATORS: Generate a support log
-#: data/ui/preferences-window.ui:929 src/preferences/service.js:423
+#: data/ui/preferences-window.ui:931 src/preferences/service.js:414
 msgid "Generate Support Log"
 msgstr ""
 
-#: data/ui/preferences-window.ui:937
+#: data/ui/preferences-window.ui:939
 msgid "About GSConnect"
 msgstr ""
 
@@ -653,75 +662,65 @@ msgstr ""
 msgid "%s is already being used"
 msgstr ""
 
-#: src/preferences/service.js:23
-msgid ""
-"The <tt>openssl</tt> command-line tool does not appear to be installed.\n"
-"Use your distro's package manager to install it, then restart or log out and "
-"back in.\n"
-"For more information, visit <a href=\"https://github.com/gsconnect/gnome-"
-"shell-extension-gsconnect/wiki/Error#openssl-not-found\">the GSConnect wiki</"
-"a>"
-msgstr ""
-
-#: src/preferences/service.js:382
+#: src/preferences/service.js:373
 msgid "A complete KDE Connect implementation for GNOME"
 msgstr ""
 
 #. TRANSLATORS: eg. 'Translator Name <your.email@domain.com>'
-#: src/preferences/service.js:391
+#: src/preferences/service.js:382
 msgid "translator-credits"
 msgstr ""
 
-#: src/preferences/service.js:424
+#: src/preferences/service.js:415
 msgid ""
 "Debug messages are being logged. Take any steps necessary to reproduce a "
 "problem then review the log."
 msgstr ""
 
-#: src/preferences/service.js:427
+#: src/preferences/service.js:418
 msgid "Review Log"
 msgstr ""
 
-#: src/preferences/service.js:452
+#: src/preferences/service.js:443
 msgid "Invalid Device Name"
 msgstr ""
 
 #. TRANSLATOR: %s is a list of forbidden characters
-#: src/preferences/service.js:454
+#: src/preferences/service.js:445
 #, javascript-format
 msgid ""
 "Device name must not contain any of %s and have a length of 1-32 characters"
 msgstr ""
 
-#: src/preferences/service.js:517
+#: src/preferences/service.js:508
 msgid "Laptop"
 msgstr ""
 
-#: src/preferences/service.js:519
+#: src/preferences/service.js:510
 msgid "Smartphone"
 msgstr ""
 
-#: src/preferences/service.js:521
+#: src/preferences/service.js:512
 msgid "Tablet"
 msgstr ""
 
-#: src/preferences/service.js:523
+#: src/preferences/service.js:514
 msgid "Television"
 msgstr ""
 
-#: src/preferences/service.js:545
+#: src/preferences/service.js:536
 msgid "Unpaired"
 msgstr ""
 
-#: src/preferences/service.js:549
+#: src/preferences/service.js:540
 msgid "Disconnected"
 msgstr ""
 
-#: src/preferences/service.js:553
+#: src/preferences/service.js:544
 msgid "Connected"
 msgstr ""
 
-#: src/preferences/service.js:689
+#: src/preferences/service.js:680
 msgid "Waiting for service…"
 msgstr ""
 

--- a/po/org.gnome.Shell.Extensions.GSConnect.pot
+++ b/po/org.gnome.Shell.Extensions.GSConnect.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: org.gnome.Shell.Extensions.GSConnect\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-24 16:26-0400\n"
+"POT-Creation-Date: 2025-08-29 15:28-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -98,7 +98,7 @@ msgstr ""
 #: data/ui/preferences-shortcut-editor.ui:19
 #: data/ui/service-device-chooser.ui:21 data/ui/service-device-chooser.ui:25
 #: data/ui/service-error-dialog.ui:20 data/ui/service-error-dialog.ui:28
-#: src/preferences/service.js:405 src/service/plugins/share.js:179
+#: src/preferences/service.js:426 src/service/plugins/share.js:179
 #: src/service/plugins/share.js:314 src/service/plugins/share.js:445
 msgid "Cancel"
 msgstr ""
@@ -116,7 +116,7 @@ msgid "No contacts"
 msgstr ""
 
 #: data/ui/contact-chooser.ui:68 data/ui/messaging-window.ui:103
-#: data/ui/mousepad-input-dialog.ui:56 data/ui/preferences-window.ui:847
+#: data/ui/mousepad-input-dialog.ui:56 data/ui/preferences-window.ui:933
 msgid "Help"
 msgstr ""
 
@@ -130,8 +130,8 @@ msgid "Other"
 msgstr ""
 
 #. TRANSLATORS: Share URL by SMS
-#: data/ui/legacy-messaging-dialog.ui:15 src/service/daemon.js:333
-#: src/service/daemon.js:447 src/service/plugins/sms.js:62
+#: data/ui/legacy-messaging-dialog.ui:15 src/service/daemon.js:341
+#: src/service/daemon.js:455 src/service/plugins/sms.js:62
 #: webextension/gettext.js:41
 msgid "Send SMS"
 msgstr ""
@@ -220,7 +220,7 @@ msgstr ""
 msgid "Open"
 msgstr ""
 
-#: data/ui/preferences-device-panel.ui:53 src/preferences/service.js:504
+#: data/ui/preferences-device-panel.ui:53 src/preferences/service.js:525
 msgid "Desktop"
 msgstr ""
 
@@ -407,7 +407,7 @@ msgstr ""
 
 #. TRANSLATORS: Send a pair request to the device
 #: data/ui/preferences-device-panel.ui:2624
-#: data/ui/preferences-device-panel.ui:2716 src/service/daemon.js:426
+#: data/ui/preferences-device-panel.ui:2716 src/service/daemon.js:434
 msgid "Pair"
 msgstr ""
 
@@ -425,7 +425,7 @@ msgid "Encryption Info"
 msgstr ""
 
 #. TRANSLATORS: Unpair the device and notify it
-#: data/ui/preferences-device-panel.ui:2722 src/service/daemon.js:435
+#: data/ui/preferences-device-panel.ui:2722 src/service/daemon.js:443
 msgid "Unpair"
 msgstr ""
 
@@ -506,7 +506,7 @@ msgstr ""
 msgid "Devices"
 msgstr ""
 
-#: data/ui/preferences-window.ui:328 src/preferences/service.js:666
+#: data/ui/preferences-window.ui:328 src/preferences/service.js:687
 msgid "Searching for devices…"
 msgstr ""
 
@@ -530,35 +530,39 @@ msgstr ""
 msgid "This device is invisible to unpaired devices"
 msgstr ""
 
-#: data/ui/preferences-window.ui:772 src/service/manager.js:163
+#: data/ui/preferences-window.ui:772 src/service/manager.js:172
 msgid "Discovery Disabled"
 msgstr ""
 
+#: data/ui/preferences-window.ui:858
+msgid "OpenSSL Missing"
+msgstr ""
+
 #. TRANSLATORS: Open a dialog to connect to an IP or Bluez device
-#: data/ui/preferences-window.ui:821
+#: data/ui/preferences-window.ui:907
 msgid "Add device by IP…"
 msgstr ""
 
-#: data/ui/preferences-window.ui:826
+#: data/ui/preferences-window.ui:912
 msgid "Display Mode"
 msgstr ""
 
 #. TRANSLATORS: Show device indicators in the top bar
-#: data/ui/preferences-window.ui:829
+#: data/ui/preferences-window.ui:915
 msgid "Panel"
 msgstr ""
 
 #. TRANSLATORS: Show devices in the user menu like Bluetooth
-#: data/ui/preferences-window.ui:835
+#: data/ui/preferences-window.ui:921
 msgid "User Menu"
 msgstr ""
 
 #. TRANSLATORS: Generate a support log
-#: data/ui/preferences-window.ui:843 src/preferences/service.js:402
+#: data/ui/preferences-window.ui:929 src/preferences/service.js:423
 msgid "Generate Support Log"
 msgstr ""
 
-#: data/ui/preferences-window.ui:851
+#: data/ui/preferences-window.ui:937
 msgid "About GSConnect"
 msgstr ""
 
@@ -649,153 +653,163 @@ msgstr ""
 msgid "%s is already being used"
 msgstr ""
 
-#: src/preferences/service.js:361
+#: src/preferences/service.js:23
+msgid ""
+"The <tt>openssl</tt> command-line tool does not appear to be installed.\n"
+"Use your distro's package manager to install it, then restart or log out and "
+"back in.\n"
+"For more information, visit <a href=\"https://github.com/gsconnect/gnome-"
+"shell-extension-gsconnect/wiki/Error#openssl-not-found\">the GSConnect wiki</"
+"a>"
+msgstr ""
+
+#: src/preferences/service.js:382
 msgid "A complete KDE Connect implementation for GNOME"
 msgstr ""
 
 #. TRANSLATORS: eg. 'Translator Name <your.email@domain.com>'
-#: src/preferences/service.js:370
+#: src/preferences/service.js:391
 msgid "translator-credits"
 msgstr ""
 
-#: src/preferences/service.js:403
+#: src/preferences/service.js:424
 msgid ""
 "Debug messages are being logged. Take any steps necessary to reproduce a "
 "problem then review the log."
 msgstr ""
 
-#: src/preferences/service.js:406
+#: src/preferences/service.js:427
 msgid "Review Log"
 msgstr ""
 
-#: src/preferences/service.js:431
+#: src/preferences/service.js:452
 msgid "Invalid Device Name"
 msgstr ""
 
 #. TRANSLATOR: %s is a list of forbidden characters
-#: src/preferences/service.js:433
+#: src/preferences/service.js:454
 #, javascript-format
 msgid ""
 "Device name must not contain any of %s and have a length of 1-32 characters"
 msgstr ""
 
-#: src/preferences/service.js:496
+#: src/preferences/service.js:517
 msgid "Laptop"
 msgstr ""
 
-#: src/preferences/service.js:498
+#: src/preferences/service.js:519
 msgid "Smartphone"
 msgstr ""
 
-#: src/preferences/service.js:500
+#: src/preferences/service.js:521
 msgid "Tablet"
 msgstr ""
 
-#: src/preferences/service.js:502
+#: src/preferences/service.js:523
 msgid "Television"
 msgstr ""
 
-#: src/preferences/service.js:524
+#: src/preferences/service.js:545
 msgid "Unpaired"
 msgstr ""
 
-#: src/preferences/service.js:528
+#: src/preferences/service.js:549
 msgid "Disconnected"
 msgstr ""
 
-#: src/preferences/service.js:532
+#: src/preferences/service.js:553
 msgid "Connected"
 msgstr ""
 
-#: src/preferences/service.js:668
+#: src/preferences/service.js:689
 msgid "Waiting for service…"
 msgstr ""
 
 #. Notify the user
-#: src/service/daemon.js:94
+#: src/service/daemon.js:95
 msgid "Settings Migrated"
 msgstr ""
 
-#: src/service/daemon.js:95
+#: src/service/daemon.js:96
 msgid ""
 "GSConnect has updated to support changes to the KDE Connect protocol. Some "
 "devices may need to be re-paired."
 msgstr ""
 
-#: src/service/daemon.js:231
+#: src/service/daemon.js:232
 msgid "Click for help troubleshooting"
 msgstr ""
 
-#: src/service/daemon.js:242
+#: src/service/daemon.js:243
 msgid "Click for more information"
 msgstr ""
 
-#: src/service/daemon.js:339
+#: src/service/daemon.js:347
 msgid "Dial Number"
 msgstr ""
 
-#: src/service/daemon.js:345 src/service/daemon.js:534
+#: src/service/daemon.js:353 src/service/daemon.js:542
 #: src/service/plugins/share.js:31
 msgid "Share File"
 msgstr ""
 
-#: src/service/daemon.js:396
+#: src/service/daemon.js:404
 msgid "List available devices"
 msgstr ""
 
-#: src/service/daemon.js:405
+#: src/service/daemon.js:413
 msgid "List all devices"
 msgstr ""
 
-#: src/service/daemon.js:414
+#: src/service/daemon.js:422
 msgid "Target Device"
 msgstr ""
 
-#: src/service/daemon.js:456
+#: src/service/daemon.js:464
 msgid "Message Body"
 msgstr ""
 
-#: src/service/daemon.js:468 src/service/plugins/notification.js:57
+#: src/service/daemon.js:476 src/service/plugins/notification.js:57
 msgid "Send Notification"
 msgstr ""
 
-#: src/service/daemon.js:477
+#: src/service/daemon.js:485
 msgid "Notification App Name"
 msgstr ""
 
-#: src/service/daemon.js:486
+#: src/service/daemon.js:494
 msgid "Notification Body"
 msgstr ""
 
-#: src/service/daemon.js:495
+#: src/service/daemon.js:503
 msgid "Notification Icon"
 msgstr ""
 
-#: src/service/daemon.js:504
+#: src/service/daemon.js:512
 msgid "Notification ID"
 msgstr ""
 
-#: src/service/daemon.js:513 src/service/plugins/ping.js:13
+#: src/service/daemon.js:521 src/service/plugins/ping.js:13
 #: src/service/plugins/ping.js:20 src/service/plugins/ping.js:47
 msgid "Ping"
 msgstr ""
 
-#: src/service/daemon.js:522 src/service/plugins/battery.js:247
+#: src/service/daemon.js:530 src/service/plugins/battery.js:247
 #: src/service/plugins/battery.js:276 src/service/plugins/battery.js:305
 #: src/service/plugins/findmyphone.js:22
 msgid "Ring"
 msgstr ""
 
-#: src/service/daemon.js:543 src/service/plugins/share.js:47
+#: src/service/daemon.js:551 src/service/plugins/share.js:47
 #: src/service/ui/messaging.js:1257 src/service/ui/messaging.js:1265
 msgid "Share Link"
 msgstr ""
 
-#: src/service/daemon.js:552 src/service/plugins/share.js:39
+#: src/service/daemon.js:560 src/service/plugins/share.js:39
 msgid "Share Text"
 msgstr ""
 
-#: src/service/daemon.js:564
+#: src/service/daemon.js:572
 msgid "Show release version"
 msgstr ""
 
@@ -839,11 +853,11 @@ msgstr ""
 msgid "Device clocks are out of sync"
 msgstr ""
 
-#: src/service/init.js:347
+#: src/service/init.js:349
 msgid "OpenSSL not found"
 msgstr ""
 
-#: src/service/manager.js:164
+#: src/service/manager.js:173
 msgid ""
 "Discovery has been disabled due to the number of devices on this network."
 msgstr ""

--- a/src/preferences/service.js
+++ b/src/preferences/service.js
@@ -17,14 +17,6 @@ import {Service} from '../utils/remote.js';
 
 
 /*
- * Translatable markup for missing-openssl infobar
- */
-const OPENSSL_MESSAGE = _(
-    'The <tt>openssl</tt> command-line tool does not appear to be installed.\nUse your distro\'s package manager to install it, then restart or log out and back in.\nFor more information, visit <a href="https://github.com/gsconnect/gnome-shell-extension-gsconnect/wiki/Error#openssl-not-found">the GSConnect wiki</a>'
-);
-
-
-/*
  * Header for support logs
  */
 const LOG_HEADER = new GLib.Bytes(`
@@ -155,7 +147,7 @@ export const Window = GObject.registerClass({
     Children: [
         // HeaderBar
         'headerbar', 'stack',
-        'infobar_discoverable', 'infobar_openssl', 'openssl_message',
+        'infobar_discoverable', 'infobar_openssl',
         'service-menu', 'service-edit', 'refresh-button',
         'device-menu', 'prev-button',
 
@@ -219,7 +211,6 @@ export const Window = GObject.registerClass({
         this.add_action(this.settings.create_action('discoverable'));
 
         // OpenSSL-missing infobar
-        this.openssl_message.set_markup(OPENSSL_MESSAGE);
         this.settings.bind(
             'missing-openssl',
             this.infobar_openssl,

--- a/src/preferences/service.js
+++ b/src/preferences/service.js
@@ -499,6 +499,14 @@ export const Window = GObject.registerClass({
         this.service_edit.grab_focus();
     }
 
+    _onRetryOpenssl(button, event) {
+        this.settings.set_boolean('enabled', false);
+        GLib.timeout_add_seconds(GLib.PRIORITY_DEFAULT_IDLE, 2, () => {
+            this.settings.set_boolean('enabled', true);
+            return GLib.SOURCE_REMOVE;
+        });
+    }
+
     /*
      * Context Switcher
      */

--- a/src/service/daemon.js
+++ b/src/service/daemon.js
@@ -21,6 +21,7 @@ import Config from '../config.js';
 import Device from './device.js';
 import Manager from './manager.js';
 import * as ServiceUI from './ui/service.js';
+import {DependencyError} from '../utils/exceptions.js';
 
 import('gi://GioUnix?version=2.0').catch(() => {}); // Set version for optional dependency
 
@@ -54,8 +55,8 @@ const Service = GObject.registerClass({
             GLib.build_filenamev([Config.CONFIGDIR, 'certificate.pem']),
             GLib.build_filenamev([Config.CONFIGDIR, 'private.pem']),
         ];
-        const certificate = Gio.TlsCertificate.new_for_paths(certPath, keyPath,
-            null);
+
+        const certificate = Gio.TlsCertificate.new_for_paths(certPath, keyPath, null);
 
         if (Device.validateId(certificate.common_name))
             return;
@@ -298,7 +299,14 @@ const Service = GObject.registerClass({
         this._initActions();
 
         // TODO: remove after a reasonable period of time
-        this._migrateConfiguration();
+        try {
+            this._migrateConfiguration();
+            this.settings.set_boolean('missing-openssl', false);
+        } catch (e) {
+            if (e instanceof DependencyError && e.dependency === 'openssl')
+                this.settings.set_boolean('missing-openssl', true);
+            throw e;
+        }
 
         this.manager.start();
     }

--- a/src/service/daemon.js
+++ b/src/service/daemon.js
@@ -303,8 +303,10 @@ const Service = GObject.registerClass({
             this._migrateConfiguration();
             this.settings.set_boolean('missing-openssl', false);
         } catch (e) {
-            if (e instanceof MissingOpensslError)
+            if (e instanceof MissingOpensslError) {
                 this.settings.set_boolean('missing-openssl', true);
+                this.notify_error(e);
+            }
             throw e;
         }
 

--- a/src/service/daemon.js
+++ b/src/service/daemon.js
@@ -21,7 +21,7 @@ import Config from '../config.js';
 import Device from './device.js';
 import Manager from './manager.js';
 import * as ServiceUI from './ui/service.js';
-import {DependencyError} from '../utils/exceptions.js';
+import {MissingOpensslError} from '../utils/exceptions.js';
 
 import('gi://GioUnix?version=2.0').catch(() => {}); // Set version for optional dependency
 
@@ -303,7 +303,7 @@ const Service = GObject.registerClass({
             this._migrateConfiguration();
             this.settings.set_boolean('missing-openssl', false);
         } catch (e) {
-            if (e instanceof DependencyError && e.dependency === 'openssl')
+            if (e instanceof MissingOpensslError)
                 this.settings.set_boolean('missing-openssl', true);
             throw e;
         }

--- a/src/service/init.js
+++ b/src/service/init.js
@@ -10,6 +10,7 @@ import GLib from 'gi://GLib';
 
 import Config from '../config.js';
 import {setup, setupGettext} from '../utils/setup.js';
+import {DependencyError} from '../utils/exceptions.js';
 
 
 // Promise Wrappers
@@ -340,10 +341,11 @@ GLib.Variant.prototype.full_unpack = _full_unpack;
  * @param {string} keyPath - Absolute path to a private key in PEM format
  * @param {string} commonName - A unique common name for the certificate
  * @returns {Gio.TlsCertificate} A TLS certificate
+ * @throws DependencyError on missing openssl tool
  */
 Gio.TlsCertificate.new_for_paths = function (certPath, keyPath, commonName = null) {
     if (GLib.find_program_in_path(Config.OPENSSL_PATH) === null) {
-        const error = new Error();
+        const error = new DependencyError('openssl');
         error.name = _('OpenSSL not found');
         error.url = `${Config.PACKAGE_URL}/wiki/Error#openssl-not-found`;
         throw error;

--- a/src/service/init.js
+++ b/src/service/init.js
@@ -10,7 +10,7 @@ import GLib from 'gi://GLib';
 
 import Config from '../config.js';
 import {setup, setupGettext} from '../utils/setup.js';
-import {DependencyError} from '../utils/exceptions.js';
+import {MissingOpensslError} from '../utils/exceptions.js';
 
 
 // Promise Wrappers
@@ -341,11 +341,11 @@ GLib.Variant.prototype.full_unpack = _full_unpack;
  * @param {string} keyPath - Absolute path to a private key in PEM format
  * @param {string} commonName - A unique common name for the certificate
  * @returns {Gio.TlsCertificate} A TLS certificate
- * @throws DependencyError on missing openssl tool
+ * @throws MissingOpensslError on missing openssl binary
  */
 Gio.TlsCertificate.new_for_paths = function (certPath, keyPath, commonName = null) {
     if (GLib.find_program_in_path(Config.OPENSSL_PATH) === null) {
-        const error = new DependencyError('openssl');
+        const error = new MissingOpensslError();
         error.name = _('OpenSSL not found');
         error.url = `${Config.PACKAGE_URL}/wiki/Error#openssl-not-found`;
         throw error;

--- a/src/service/manager.js
+++ b/src/service/manager.js
@@ -111,8 +111,11 @@ const Manager = GObject.registerClass({
                     null);
                 this.settings.set_boolean('missing-openssl', false);
             } catch (e) {
-                if (e instanceof MissingOpensslError)
+                if (e instanceof MissingOpensslError) {
                     this.settings.set_boolean('missing-openssl', true);
+                    const app = Gio.Application.get_default();
+                    app?.notify_error(e);
+                }
                 throw e;
             }
         }

--- a/src/service/manager.js
+++ b/src/service/manager.js
@@ -104,17 +104,19 @@ const Manager = GObject.registerClass({
 
     get certificate() {
         if (this._certificate === undefined) {
+            const app = Gio.Application.get_default();
             try {
                 this._certificate = Gio.TlsCertificate.new_for_paths(
                     GLib.build_filenamev([Config.CONFIGDIR, 'certificate.pem']),
                     GLib.build_filenamev([Config.CONFIGDIR, 'private.pem']),
                     null);
+                if (this.settings.get_boolean('missing-openssl'))
+                    app?.withdraw_notification('gsconnect-missing-openssl');
                 this.settings.set_boolean('missing-openssl', false);
             } catch (e) {
                 if (e instanceof MissingOpensslError) {
                     this.settings.set_boolean('missing-openssl', true);
-                    const app = Gio.Application.get_default();
-                    app?.notify_error(e);
+                    app?.notify_error(e, 'gsconnect-missing-openssl');
                 }
                 throw e;
             }

--- a/src/service/manager.js
+++ b/src/service/manager.js
@@ -13,7 +13,7 @@ import Device from './device.js';
 
 import * as LanBackend from './backends/lan.js';
 
-import {DependencyError} from '../utils/exceptions.js';
+import {MissingOpensslError} from '../utils/exceptions.js';
 
 const DEVICE_NAME = 'org.gnome.Shell.Extensions.GSConnect.Device';
 const DEVICE_PATH = '/org/gnome/Shell/Extensions/GSConnect/Device';
@@ -111,7 +111,7 @@ const Manager = GObject.registerClass({
                     null);
                 this.settings.set_boolean('missing-openssl', false);
             } catch (e) {
-                if (e instanceof DependencyError && e.dependency === 'openssl')
+                if (e instanceof MissingOpensslError)
                     this.settings.set_boolean('missing-openssl', true);
                 throw e;
             }

--- a/src/utils/exceptions.js
+++ b/src/utils/exceptions.js
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: GSConnect Developers https://github.com/GSConnect
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+export class DependencyError extends Error {
+    constructor(dependency, message) {
+        super(message);
+        this.name = 'DependencyError';
+        this.dependency = dependency;
+    }
+}

--- a/src/utils/exceptions.js
+++ b/src/utils/exceptions.js
@@ -2,10 +2,9 @@
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-export class DependencyError extends Error {
-    constructor(dependency, message) {
+export class MissingOpensslError extends Error {
+    constructor(message) {
         super(message);
-        this.name = 'DependencyError';
-        this.dependency = dependency;
+        this.name = 'MissingOpensslError';
     }
 }


### PR DESCRIPTION
I owe... several users an apology.

For the longest time, I had it in my head that there was a notification displayed by GSConnect when the `openssl` command was missing.

In fact, that's not the case, and the _only_ indication of a problem is buried in our log output found in the user journal.

So, no more. This PR adds that notification, as well as an infobar in the GSConnect Preferences window, which will be activated whenever the code detects that the `openssl` command is not available on the system.

In that scenario, a message will be displayed directing the user to the wiki page about the issue:

(This will say "**OpenSSL not found**" actually, I changed it to avoid adding a new string.)
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;↓↓↓↓↓↓↓↓
<img width="857" height="748" alt="image" src="https://github.com/user-attachments/assets/0bf06dcc-62fb-4597-9e3e-012594dd44c3" />

I was _hoping_ to provide a "Retry" button that could be clicked after installing, to reset the detection process and get the daemon started up correctly. But that proved too challenging. (Too much of the initialization process is one-shot code that's already in an unrecoverably broken state after it hits the initial error.) So, instructing the user to restart / cycle their login is the best I could do.

Fixes #1834 