### PR TITLE
GNOME 49 support

### DIFF
--- a/data/metadata.json.in
+++ b/data/metadata.json.in
@@ -3,6 +3,6 @@
     "name": "GSConnect",
     "description": "GSConnect is a complete implementation of KDE Connect especially for GNOME Shell with Nautilus, Chrome and Firefox integration. It does not rely on the KDE Connect desktop application and will not work with it installed.\n\nKDE Connect allows devices to securely share content like notifications or files and other features like SMS messaging and remote control. The KDE Connect team has applications for Linux, BSD, Android, Sailfish, iOS, macOS and Windows.\n\nPlease report issues on Github!",
     "version": @PACKAGE_VERSION@,
-    "shell-version": [ "46", "47", "48" ],
+    "shell-version": [ "46", "47", "48", "49" ],
     "url": "@PACKAGE_URL@/wiki"
 }

--- a/src/service/components/pulseaudio.js
+++ b/src/service/components/pulseaudio.js
@@ -15,8 +15,17 @@ let Gvc = null;
 try {
     // Add gnome-shell's typelib dir to the search path
     const typelibDir = GLib.build_filenamev([Config.GNOME_SHELL_LIBDIR, 'gnome-shell']);
-    GIRepository.Repository.prepend_search_path(typelibDir);
-    GIRepository.Repository.prepend_library_path(typelibDir);
+
+    if (GIRepository.Repository.hasOwnProperty('prepend_search_path')) {
+        // GNOME <= 48 / GIRepository 2.0
+        GIRepository.Repository.prepend_search_path(typelibDir);
+        GIRepository.Repository.prepend_library_path(typelibDir);
+    } else {
+        // GNOME 49+ / GIRepository 3.0
+        const repo = GIRepository.Repository.dup_default();
+        repo.prepend_search_path(typelibDir);
+        repo.prepend_library_path(typelibDir);
+    }
 
     Gvc = (await import('gi://Gvc')).default;
 } catch {}

--- a/src/service/daemon.js
+++ b/src/service/daemon.js
@@ -7,11 +7,17 @@
 import Gdk from 'gi://Gdk?version=3.0';
 import 'gi://GdkPixbuf?version=2.0';
 import Gio from 'gi://Gio?version=2.0';
-import 'gi://GIRepository?version=2.0';
 import GLib from 'gi://GLib?version=2.0';
 import GObject from 'gi://GObject?version=2.0';
 import Gtk from 'gi://Gtk?version=3.0';
 import 'gi://Pango?version=1.0';
+
+// GNOME 49 uses GIRepository 3.0
+import('gi://GIRepository?version=3.0').catch(() => {
+    import('gi://GIRepository?version=2.0').catch(() => {});
+});
+
+import('gi://GioUnix?version=2.0').catch(() => {}); // Set version for optional dependency
 
 import system from 'system';
 
@@ -21,8 +27,6 @@ import Config from '../config.js';
 import Device from './device.js';
 import Manager from './manager.js';
 import * as ServiceUI from './ui/service.js';
-
-import('gi://GioUnix?version=2.0').catch(() => {}); // Set version for optional dependency
 
 
 /**

--- a/src/service/init.js
+++ b/src/service/init.js
@@ -62,10 +62,22 @@ const extensionFolder = GLib.path_get_dirname(serviceFolder);
 setup(extensionFolder);
 setupGettext();
 
+
 if (Config.IS_USER) {
     // Infer libdir by assuming gnome-shell shares a common prefix with gjs;
     // assume the parent directory if it's not there
-    let libdir = GIRepository.Repository.get_search_path().find(path => {
+    let gir_paths;
+
+    if (GIRepository.Repository.hasOwnProperty('get_search_path')) {
+        // GNOME <= 48 / GIRepository 2.0
+        gir_paths = GIRepository.Repository.get_search_path();
+    } else {
+        // GNOME 49+ / GIRepository 3.0
+        const repo = GIRepository.Repository.dup_default();
+        gir_paths = repo.get_search_path();
+    }
+
+    let libdir = gir_paths.find(path => {
         return path.endsWith('/gjs/girepository-1.0');
     }).replace('/gjs/girepository-1.0', '');
 

--- a/src/service/plugins/systemvolume.js
+++ b/src/service/plugins/systemvolume.js
@@ -16,8 +16,17 @@ let Gvc = null;
 try {
     // Add gnome-shell's typelib dir to the search path
     const typelibDir = GLib.build_filenamev([Config.GNOME_SHELL_LIBDIR, 'gnome-shell']);
-    GIRepository.Repository.prepend_search_path(typelibDir);
-    GIRepository.Repository.prepend_library_path(typelibDir);
+
+    if (GIRepository.Repository.hasOwnProperty('prepend_search_path')) {
+        // GNOME <= 48 / GIRepository 2.0
+        GIRepository.Repository.prepend_search_path(typelibDir);
+        GIRepository.Repository.prepend_library_path(typelibDir);
+    } else {
+        // GNOME 49+ / GIRepository 3.0
+        const repo = GIRepository.Repository.dup_default();
+        repo.prepend_search_path(typelibDir);
+        repo.prepend_library_path(typelibDir);
+    }
 
     Gvc = (await import('gi://Gvc')).default;
 } catch {}


### PR DESCRIPTION
This is the first set of changes required to support GNOME 49, which includes a new GIRepository version 3.0 that requires some adaptation.

Until GNOME 49 is out of beta, we can't be certain these changes are complete, but they're what we know we need so far.

Fixes #2048 