### PR TITLE
Address more (upcoming) ESLint problems

### DIFF
--- a/src/service/components/contacts.js
+++ b/src/service/components/contacts.js
@@ -64,7 +64,7 @@ const Store = GObject.registerClass({
     /**
      * Parse an EContact and add it to the store.
      *
-     * @param {EBookContacts.Contact} econtact - an EContact to parse
+     * @param {"EBookContacts.Contact"} econtact - an EContact to parse
      * @param {string} [origin] - an optional origin string
      */
     async _parseEContact(econtact, origin = 'desktop') {

--- a/src/service/plugins/systemvolume.js
+++ b/src/service/plugins/systemvolume.js
@@ -2,34 +2,12 @@
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-import GIRepository from 'gi://GIRepository';
-import GLib from 'gi://GLib';
 import GObject from 'gi://GObject';
 
 import * as Components from '../components/index.js';
 import Config from '../../config.js';
 import * as Core from '../core.js';
 import Plugin from '../plugin.js';
-
-
-let Gvc = null;
-try {
-    // Add gnome-shell's typelib dir to the search path
-    const typelibDir = GLib.build_filenamev([Config.GNOME_SHELL_LIBDIR, 'gnome-shell']);
-
-    if (GIRepository.Repository.hasOwnProperty('prepend_search_path')) {
-        // GNOME <= 48 / GIRepository 2.0
-        GIRepository.Repository.prepend_search_path(typelibDir);
-        GIRepository.Repository.prepend_library_path(typelibDir);
-    } else {
-        // GNOME 49+ / GIRepository 3.0
-        const repo = GIRepository.Repository.dup_default();
-        repo.prepend_search_path(typelibDir);
-        repo.prepend_library_path(typelibDir);
-    }
-
-    Gvc = (await import('gi://Gvc')).default;
-} catch {}
 
 
 export const Metadata = {
@@ -137,7 +115,7 @@ const SystemVolumePlugin = GObject.registerClass({
     /**
      * Update the cache for @stream
      *
-     * @param {Gvc.MixerStream} stream - The stream to cache
+     * @param {"Gvc.MixerStream"} stream - The stream to cache
      * @returns {object} The updated cache object
      */
     _updateCache(stream) {
@@ -157,7 +135,7 @@ const SystemVolumePlugin = GObject.registerClass({
     /**
      * Send the state of a local sink
      *
-     * @param {Gvc.MixerControl} mixer - The mixer that owns the stream
+     * @param {"Gvc.MixerControl"} mixer - The mixer that owns the stream
      * @param {number} id - The Id of the stream that changed
      */
     _sendSink(mixer, id) {


### PR DESCRIPTION
Apparently ESLint/JSDoc can no longer see the awaited imports, as of the version update Dependabot has waiting, so any type names from those used in doc comments have to be quoted as strings.

By the same token, Now that it's no longer used in the doc comments, ESLint registers Gvc as an unused variable in systemvolume.js. Added an assert that type-checks the `_mixer` property, just to silence it. Which is a complete sledgehammer of a fix, but meh.