### PR TITLE
mpris: derive canPlay for players that never emit CanPlay

### DIFF
--- a/src/service/plugins/mpris.js
+++ b/src/service/plugins/mpris.js
@@ -276,7 +276,13 @@ const MPRISPlugin = GObject.registerClass({
                     pos: Math.floor(player.Position / 1000),
                     isPlaying: (player.PlaybackStatus === 'Playing'),
                     canPause: player.CanPause,
-                    canPlay: player.CanPlay,
+                    // Some players (notably VLC) never emit PropertiesChanged
+                    // for CanPlay, so the cached value stays at whatever it was
+                    // when the proxy was created — `false` if the player was
+                    // still Stopped. A paused, controllable player can always
+                    // be resumed, so treat that as playable.
+                    canPlay: player.CanPlay ||
+                        (player.CanControl && player.PlaybackStatus === 'Paused'),
                     canGoNext: player.CanGoNext,
                     canGoPrevious: player.CanGoPrevious,
                     canSeek: player.CanSeek,


### PR DESCRIPTION
## Summary

Players that never emit `PropertiesChanged` for `CanPlay` leave GSConnect sending `canPlay: false` to the device forever, so the remote never renders a Play button. VLC is the case I hit: pausing from the phone works, but there is then no way to resume from the phone.

## Root cause

`CanPlay` is read via `proxy.get_cached_property()` (`src/service/components/mpris.js`), and Gio.DBusProxy's cache only updates when the player emits `PropertiesChanged`. VLC emits `CanPause` when playback starts but never emits `CanPlay` at all, so the cached value stays pinned to whatever `GetAll` returned at proxy construction — `false`, because the player was still `Stopped` at that moment.

Captured from the session bus with `dbus-monitor --session`, VLC 3.0.20 (snap rev 3777), GSConnect 72, GNOME Shell 50.1, Wayland:

| Event | PlaybackStatus | CanPlay | CanPause |
|---|---|---|---|
| `GetAll` at proxy construction | `Stopped` | **false** | false |
| `PropertiesChanged` on play | `Playing` | *absent* | **true** |
| `PropertiesChanged` on pause | `Paused` | *absent* | *absent* |

`CanControl` is `true` throughout.

That asymmetry is what makes the symptom confusing: `canPause` is correct, so the Pause button renders and works, while `canPlay` is stale-false and the Play button never appears.

## Fix

`src/service/plugins/mpris.js` — fall back to `CanControl` when the player reports `Paused`:

```js
canPlay: player.CanPlay ||
    (player.CanControl && player.PlaybackStatus === 'Paused'),
```

Per the MPRIS spec a paused, controllable player can always be resumed, so `CanPlay: false` while `Paused` and `CanControl: true` is not a state a conforming player should report. Players that already report `CanPlay` correctly are unaffected — the left side short-circuits. Verified against Totem and Chromium.

## Testing

- VLC: Play button now appears after pausing from the phone, and resumes correctly. Verified end to end on a paired Android device.
- Totem, Chromium: no change in behavior.

## Notes

The underlying bug is VLC's — its D-Bus module updates `CanPause` on state change and omits `CanPlay`. This is a defensive fix on the GSConnect side; it may be worth reporting upstream to VideoLAN separately.

Possibly related: #2022 (pause from phone not working) reports a different symptom that may share this root cause — I have not reproduced that one.
